### PR TITLE
Revert "#634 - Fix order book depth chart steps"

### DIFF
--- a/src/components/trade/depthChartWidget/useDepthChartWidget.ts
+++ b/src/components/trade/depthChartWidget/useDepthChartWidget.ts
@@ -19,12 +19,14 @@ export const useDepthChartWidget = (base?: Token, quote?: Token) => {
 
   const getOrders = useCallback(
     (orders?: OrderRow[], buy?: boolean) => {
-      const res = [...(orders || [])].map(({ rate, amount }) => {
-        return [
-          +(+rate).toFixed(quote?.decimals),
-          +(+amount).toFixed(base?.decimals),
-        ];
-      });
+      const res = [...(orders || [])]
+        .splice(0, depthChartBuckets + 2)
+        .map(({ rate, amount }) => {
+          return [
+            +(+rate).toFixed(quote?.decimals),
+            +(+amount).toFixed(base?.decimals),
+          ];
+        });
 
       if (res.length > 0) {
         return res;

--- a/src/workers/sdk.ts
+++ b/src/workers/sdk.ts
@@ -219,26 +219,6 @@ const getOrderBook = async (
   const buyStartRate = hasOverlappingRates ? middleRate : maxBuy;
   const sellStartRate = hasOverlappingRates ? middleRate : minSellNormalized;
 
-  const getSteps = (start: Decimal, end: Decimal, step: Decimal): Decimal => {
-    const delta = end.minus(start);
-    return delta.div(step);
-  };
-
-  const buySteps = getSteps(minBuy, maxBuy, step);
-  const sellSteps = getSteps(minSellNormalized, maxSellNormalized, step);
-
-  const getTotalSteps = (buySteps: Decimal, sellSteps: Decimal): number => {
-    if (buySteps.gte(steps) && buySteps.gte(sellSteps)) {
-      return buySteps.floor().toNumber();
-    }
-    if (sellSteps.gte(steps) && sellSteps.gte(buySteps)) {
-      return sellSteps.floor().toNumber();
-    }
-    return steps;
-  };
-
-  const totalSteps = getTotalSteps(buySteps, sellSteps);
-
   const buy = buyHasLiq
     ? await buildOrderBook(
         true,
@@ -248,7 +228,7 @@ const getOrderBook = async (
         step,
         minBuy,
         maxBuy,
-        totalSteps
+        steps
       )
     : [];
 
@@ -261,7 +241,7 @@ const getOrderBook = async (
         step,
         minSell,
         maxSell,
-        totalSteps
+        steps
       )
     : [];
 


### PR DESCRIPTION
Reverts bancorprotocol/carbon-app#635

we do it because we ended up with 50K rates, causing the app to severely lag