### PR TITLE
Windows issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,10 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "prettier/prettier": "warn"
+    "prettier/prettier": [
+      "warn",
+      { "endOfLine": "auto" }
+    ]
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "compile-abis": "typechain --target ethers-v5 --out-dir src/abis/types src/abis/**/*.json",
+    "compile-abis": "typechain --target ethers-v5 --out-dir \"src/abis/types\" \"src/abis/**/*.json\"",
     "postinstall": "yarn compile-abis",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "vite",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "compile-abis": "typechain --target ethers-v5 --out-dir 'src/abis/types' 'src/abis/**/*.json'",
+    "compile-abis": "typechain --target ethers-v5 --out-dir src/abis/types src/abis/**/*.json",
     "postinstall": "yarn compile-abis",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "vite",


### PR DESCRIPTION
Fixes two issues related to windows during installation : 
- `"endOfLine": "auto"`: fixes the `Delete 'CR'` warn on every end of line
- use escaped double quote in package.json because single quotes are interpreted as a folder name on windows