### PR TITLE
improve a11y on navigation

### DIFF
--- a/src/components/core/menu/mainMenu/MainMenuLeft.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuLeft.tsx
@@ -7,36 +7,35 @@ import { handleOnItemClick } from '../utils';
 import { useMenuItems } from '../useMenuItems';
 
 export const MainMenuLeft: FC = () => {
-  const location = useLocation();
+  const pathname = useLocation().current.pathname;
   const { menuItems } = useMenuItems();
 
   return (
-    <div>
-      <div className={'flex items-center space-s-24'}>
-        <Link
-          to={PathNames.strategies}
-          onClick={() => carbonEvents.navigation.navHomeClick(undefined)}
-        >
-          <LogoCarbon className={'w-34'} />
-        </Link>
+    <nav aria-label="Main" className={'flex items-center space-s-24'}>
+      <Link
+        to={PathNames.strategies}
+        onClick={() => carbonEvents.navigation.navHomeClick(undefined)}
+      >
+        <LogoCarbon className={'w-34'} />
+      </Link>
 
-        <div className={'hidden space-s-24 md:block'}>
-          {menuItems.map(({ label, href, hrefMatches }) => (
+      <div className={'hidden space-s-24 md:block'}>
+        {menuItems.map(({ label, href, hrefMatches }) => {
+          const isSamePage = isPathnameMatch(pathname, href, hrefMatches);
+          return (
             <Link
               onClick={() => handleOnItemClick(href)}
-              key={label}
               to={href}
+              aria-current={isSamePage ? 'page' : 'false'}
               className={`px-3 py-3 transition-colors duration-300 ${
-                isPathnameMatch(location.current.pathname, href, hrefMatches)
-                  ? 'text-white'
-                  : 'hover:text-white'
+                isSamePage ? 'text-white' : 'hover:text-white'
               }`}
             >
               {label}
             </Link>
-          ))}
-        </div>
+          );
+        })}
       </div>
-    </div>
+    </nav>
   );
 };

--- a/src/components/strategies/StrategyPageTabs.tsx
+++ b/src/components/strategies/StrategyPageTabs.tsx
@@ -17,7 +17,8 @@ interface Props {
 
 export const StrategyPageTabs = ({ currentPathname, tabs }: Props) => {
   return (
-    <div
+    <nav
+      aria-label="Strategy Panels"
       className={cn(
         'h-40',
         'w-full md:w-auto',
@@ -30,7 +31,12 @@ export const StrategyPageTabs = ({ currentPathname, tabs }: Props) => {
       )}
     >
       {tabs.map(({ label, href, icon, badge, hrefMatches }) => (
-        <Link to={href} key={href} className={'w-full'}>
+        <Link
+          to={href}
+          key={href}
+          className={'w-full'}
+          aria-current={href === currentPathname ? 'location' : 'false'}
+        >
           <Button
             variant={
               isPathnameMatch(currentPathname, href, hrefMatches)
@@ -61,6 +67,6 @@ export const StrategyPageTabs = ({ currentPathname, tabs }: Props) => {
           </Button>
         </Link>
       ))}
-    </div>
+    </nav>
   );
 };


### PR DESCRIPTION
Small PR to get to know the code. 
Improve a11y for navigation : 
- use `nav` with `aria-label` to get implicit `navigation` role ([Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav))
- use `aria-current="page"` on anchors for the main page & `aria-current="location"` for tabbed pages. ([Documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current))
- removed a div that had no impact on the UI