### PR TITLE
Replace strategy sort & filter enum

### DIFF
--- a/src/components/explorer/ExplorerSearch.tsx
+++ b/src/components/explorer/ExplorerSearch.tsx
@@ -44,12 +44,8 @@ export const ExplorerSearch: FC<ExplorerSearchProps> = (props) => {
   const onSearchHandler = useCallback(
     (v?: string) => {
       const value = v || props.search;
-      if (isInvalidAddress) {
-        return;
-      }
-      if (value.length === 0) {
-        return;
-      }
+      if (isInvalidAddress) return;
+      if (value.length === 0) return;
       if (props.type === 'token-pair' && props.filteredPairs.length === 0) {
         return;
       }

--- a/src/components/explorer/utils.ts
+++ b/src/components/explorer/utils.ts
@@ -1,8 +1,10 @@
 import { MakeGenerics } from 'libs/routing';
 
+export type ExplorerType = 'wallet' | 'token-pair';
+
 export type ExplorerRouteGenerics = MakeGenerics<{
   Params: {
-    type: 'wallet' | 'token-pair';
+    type: ExplorerType;
     slug?: string;
     address?: string;
   };

--- a/src/components/strategies/overview/StrategyContent.tsx
+++ b/src/components/strategies/overview/StrategyContent.tsx
@@ -10,7 +10,6 @@ import {
   useRef,
 } from 'react';
 import { Strategy, StrategyStatus } from 'libs/queries';
-import { StrategyFilter } from 'components/strategies/overview/StrategyFilterSort';
 import { StrategyCreateFirst } from 'components/strategies/overview/StrategyCreateFirst';
 import { useStore } from 'store';
 import { m } from 'libs/motion';
@@ -51,16 +50,10 @@ export const _StrategyContent: FC<Props> = ({
   const searchSlug = toPairSlug(search);
   const filteredStrategies = useMemo(() => {
     const filtered = strategies?.filter((strategy) => {
-      if (
-        filter === StrategyFilter.Active &&
-        strategy.status !== StrategyStatus.Active
-      ) {
+      if (filter === 'active' && strategy.status !== StrategyStatus.Active) {
         return false;
       }
-      if (
-        filter === StrategyFilter.Inactive &&
-        strategy.status === StrategyStatus.Active
-      ) {
+      if (filter === 'inactive' && strategy.status === StrategyStatus.Active) {
         return false;
       }
       if (!searchSlug) return true;

--- a/src/components/strategies/overview/StrategyFilterSort.tsx
+++ b/src/components/strategies/overview/StrategyFilterSort.tsx
@@ -5,13 +5,30 @@ import { getSortAndFilterItems } from './utils';
 import { ReactComponent as IconChevron } from 'assets/icons/chevron.svg';
 import { ReactComponent as IconCheck } from 'assets/icons/check.svg';
 
-export enum StrategyFilter {
+export const strategyFilter = {
+  all: 'All',
+  active: 'Active',
+  inactive: 'Inactive',
+};
+export type StrategyFilter = keyof typeof strategyFilter;
+
+export enum EnumStrategyFilter {
   All,
   Active,
   Inactive,
 }
 
-export enum StrategySort {
+export const strategySort = {
+  recent: 'Recently Created',
+  old: 'Oldest Created',
+  pairAsc: 'Pair (A->Z)',
+  pairDesc: 'Pair (Z->A)',
+  roiAsc: 'ROI (Ascending)',
+  roiDesc: 'ROI (Descending)',
+};
+export type StrategySort = keyof typeof strategySort;
+
+export enum EnumStrategySort {
   Recent,
   Old,
   PairAscending,

--- a/src/components/strategies/overview/utils.ts
+++ b/src/components/strategies/overview/utils.ts
@@ -1,85 +1,43 @@
 import BigNumber from 'bignumber.js';
 import { Strategy } from 'libs/queries';
-import { StrategyFilter, StrategySort } from './StrategyFilterSort';
+import {
+  StrategyFilter,
+  StrategySort,
+  strategyFilter,
+  strategySort,
+} from './StrategyFilterSort';
+
+const sortFn: Record<StrategySort, (a: Strategy, b: Strategy) => number> = {
+  recent: (a, b) =>
+    new BigNumber(a.idDisplay).minus(b.idDisplay).times(-1).toNumber(),
+  old: (a, b) => new BigNumber(a.idDisplay).minus(b.idDisplay).toNumber(),
+  pairAsc: (a, b) => {
+    return (
+      a.base.symbol.localeCompare(b.base.symbol) ||
+      a.quote.symbol.localeCompare(b.quote.symbol)
+    );
+  },
+  pairDesc: (a, b) => {
+    return (
+      b.base.symbol.localeCompare(a.base.symbol) ||
+      b.quote.symbol.localeCompare(a.quote.symbol)
+    );
+  },
+  roiAsc: (a, b) => a.roi.minus(b.roi).toNumber(),
+  roiDesc: (a, b) => a.roi.minus(b.roi).times(-1).toNumber(),
+};
 
 export const getCompareFunctionBySortType = (sortType: StrategySort) => {
-  let firstPairComparison: number;
-
-  switch (sortType) {
-    case StrategySort.Recent:
-      return (a: Strategy, b: Strategy) =>
-        new BigNumber(a.idDisplay).minus(b.idDisplay).times(-1).toNumber();
-    case StrategySort.Old:
-      return (a: Strategy, b: Strategy) =>
-        new BigNumber(a.idDisplay).minus(b.idDisplay).toNumber();
-    case StrategySort.PairAscending:
-      return (a: Strategy, b: Strategy) => {
-        firstPairComparison = a.base.symbol.localeCompare(b.base.symbol);
-        if (firstPairComparison !== 0) {
-          return firstPairComparison;
-        }
-        return a.quote.symbol.localeCompare(b.quote.symbol);
-      };
-    case StrategySort.PairDescending:
-      return (a: Strategy, b: Strategy) => {
-        firstPairComparison = b.base.symbol.localeCompare(a.base.symbol);
-        if (firstPairComparison !== 0) {
-          return firstPairComparison;
-        }
-        return b.quote.symbol.localeCompare(a.quote.symbol);
-      };
-    case StrategySort.RoiAscending:
-      return (a: Strategy, b: Strategy) => a.roi.minus(b.roi).toNumber();
-    case StrategySort.RoiDescending:
-      return (a: Strategy, b: Strategy) =>
-        a.roi.minus(b.roi).times(-1).toNumber();
-    default:
-      return (a: Strategy, b: Strategy) =>
-        new BigNumber(a.idDisplay).minus(b.idDisplay).times(-1).toNumber();
-  }
+  return sortFn[sortType] ?? sortFn['roiDesc'];
 };
 export const getSortAndFilterItems = () => {
-  const sortItems = [
-    {
-      title: 'Recently Created',
-      item: StrategySort.Recent,
-    },
-    {
-      title: 'Oldest Created',
-      item: StrategySort.Old,
-    },
-    {
-      title: 'Pair (A->Z)',
-      item: StrategySort.PairAscending,
-    },
-    {
-      title: 'Pair (Z->A)',
-      item: StrategySort.PairDescending,
-    },
-    {
-      title: 'ROI (Ascending)',
-      item: StrategySort.RoiAscending,
-    },
-    {
-      title: 'ROI (Descending)',
-      item: StrategySort.RoiDescending,
-    },
-  ];
+  const sortItems = Object.entries(strategySort).map(([item, title]) => {
+    return { item: item as StrategySort, title };
+  });
 
-  const filterItems = [
-    {
-      title: 'All',
-      item: StrategyFilter.All,
-    },
-    {
-      title: 'Active',
-      item: StrategyFilter.Active,
-    },
-    {
-      title: 'Inactive',
-      item: StrategyFilter.Inactive,
-    },
-  ];
+  const filterItems = Object.entries(strategyFilter).map(([item, title]) => {
+    return { item: item as StrategyFilter, title };
+  });
 
   return { sortItems, filterItems };
 };

--- a/src/services/localeStorage/index.ts
+++ b/src/services/localeStorage/index.ts
@@ -6,6 +6,8 @@ import { TradePair } from 'libs/modals/modals/ModalTradeTokenList';
 import { TradePairCategory } from 'libs/modals/modals/ModalTradeTokenList/ModalTradeTokenListContent';
 import { ChooseTokenCategory } from 'libs/modals/modals/ModalTokenList/ModalTokenListContent';
 import {
+  EnumStrategyFilter,
+  EnumStrategySort,
   StrategyFilter,
   StrategySort,
 } from 'components/strategies/overview/StrategyFilterSort';
@@ -32,8 +34,8 @@ interface LocalStorageSchema {
   tradeMaxOrders: string;
   chooseTokenCategory: ChooseTokenCategory;
   carbonControllerAddress: string;
-  strategyOverviewFilter: StrategyFilter;
-  strategyOverviewSort: StrategySort;
+  strategyOverviewFilter: StrategyFilter | EnumStrategyFilter;
+  strategyOverviewSort: StrategySort | EnumStrategySort;
   voucherContractAddress: string;
   tokenListCache: { tokens: Token[]; timestamp: number };
   sdkCompressedCacheData: string;

--- a/src/store/useStrategiesStore.ts
+++ b/src/store/useStrategiesStore.ts
@@ -1,4 +1,6 @@
 import {
+  EnumStrategyFilter,
+  EnumStrategySort,
   StrategyFilter,
   StrategySort,
 } from 'components/strategies/overview/StrategyFilterSort';
@@ -17,14 +19,47 @@ export interface StrategiesStore {
   setStrategyToEdit: Dispatch<SetStateAction<Strategy | undefined>>;
 }
 
+/** Used for local storage migration */
+export const strategySortMapping: Record<EnumStrategySort, StrategySort> = {
+  [EnumStrategySort.Recent]: 'recent',
+  [EnumStrategySort.Old]: 'old',
+  [EnumStrategySort.PairAscending]: 'pairAsc',
+  [EnumStrategySort.PairDescending]: 'pairDesc',
+  [EnumStrategySort.RoiAscending]: 'roiAsc',
+  [EnumStrategySort.RoiDescending]: 'roiDesc',
+};
+const isEnumSort = (
+  sort: StrategySort | EnumStrategySort
+): sort is EnumStrategySort => sort in strategySortMapping;
+
+export const getSortFromLS = (): StrategySort => {
+  const sort = lsService.getItem('strategyOverviewSort');
+  if (sort === undefined) return 'roiDesc';
+  return isEnumSort(sort) ? strategySortMapping[sort] : sort;
+};
+
+/** Used for local storage migration */
+export const strategyFilterMapping: Record<EnumStrategyFilter, StrategyFilter> =
+  {
+    [EnumStrategyFilter.All]: 'all',
+    [EnumStrategyFilter.Active]: 'active',
+    [EnumStrategyFilter.Inactive]: 'inactive',
+  };
+
+const isEnumFilter = (
+  filter: StrategyFilter | EnumStrategyFilter
+): filter is EnumStrategyFilter => filter in strategyFilterMapping;
+
+export const getFilterFromLS = (): StrategyFilter => {
+  const filter = lsService.getItem('strategyOverviewFilter');
+  if (filter === undefined) return 'all';
+  return isEnumFilter(filter) ? strategyFilterMapping[filter] : filter;
+};
+
 export const useStrategiesStore = (): StrategiesStore => {
   const [search, setSearch] = useState('');
-  const [sort, _setSort] = useState<StrategySort>(
-    lsService.getItem('strategyOverviewSort') || StrategySort.Old
-  );
-  const [filter, _setFilter] = useState<StrategyFilter>(
-    lsService.getItem('strategyOverviewFilter') || StrategyFilter.All
-  );
+  const [sort, _setSort] = useState<StrategySort>(getSortFromLS());
+  const [filter, _setFilter] = useState<StrategyFilter>(getFilterFromLS());
 
   const setSort = (sort: StrategySort) => {
     _setSort(sort);
@@ -54,9 +89,9 @@ export const useStrategiesStore = (): StrategiesStore => {
 };
 
 export const defaultStrategiesStore: StrategiesStore = {
-  filter: StrategyFilter.All,
+  filter: 'all',
   setFilter: () => {},
-  sort: StrategySort.Old,
+  sort: 'roiDesc',
   setSort: () => {},
   search: '',
   setSearch: () => {},


### PR DESCRIPTION
String literal are more readable than enum in :
- Codebase
- URL searchParams
- GTM events

As I had to send sort/filter to GTM I thought it would be better to start with this migration to string literals.

- [x] Create mapping between sort/filter and there labels (Ok because we removed i18n)
- [x] Create type from this mapping
- [x] Use mapping for sortFn instead of switch
- [x] Create localstorage migration from enum to string literal
- [x] Use "roiDesc" as default (as #798 is not yet merged)