### PR TITLE
fix: Resolve missing key prop warning

### DIFF
--- a/src/components/core/menu/mainMenu/MainMenuLeft.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuLeft.tsx
@@ -23,6 +23,7 @@ export const MainMenuLeft: FC = () => {
           const isSamePage = isPathnameMatch(pathname, href, hrefMatches);
           return (
             <Link
+              key={label}
               onClick={() => handleOnItemClick(href)}
               to={href}
               aria-current={isSamePage ? 'page' : 'false'}


### PR DESCRIPTION
Hello I was just poking around your code and noticed this warning when I ran the app locally. 

<img width="1109" alt="missingKeyProp" src="https://github.com/bancorprotocol/carbon-app/assets/143921433/dd7db199-5403-4ca1-9372-c11df777a56a">

---

Looks like this key prop used to be present but was accidentally removed recently: 
*  (https://github.com/bancorprotocol/carbon-app/commit/bd4ceb0d11ba71a3eb432b996f2d0526f148e2c4#diff-2483127c48c1a57bd3416f0cb466a828f6ca5d73eb63e30843a13d82fce0ef34L27)

I went ahead and added it again to remove this warning. I used `key={label}` because that what was present previously, as well as the approach you take in other files like this one. 

https://github.com/bancorprotocol/carbon-app/blob/deee2c581ccd7da1053733d11f609649832a80c4/src/components/core/menu/mobileMenu/MobileMenu.tsx#L13-L18