### PR TITLE
[E2E] use addresses instead of symbol for token selection

### DIFF
--- a/e2e/utils/NotificationDriver.ts
+++ b/e2e/utils/NotificationDriver.ts
@@ -26,9 +26,10 @@ export class NotificationDriver {
     return this.notif.getByTestId('notif-description');
   }
   async close() {
-    const isVisible = await this.notif.isVisible();
+    const btn = this.notif.getByTestId('notif-close');
+    const isVisible = await btn.isVisible();
     if (isVisible) {
-      this.notif.getByTestId('notif-close').click();
+      btn.click();
       return this.notif.waitFor({ state: 'detached' });
     }
   }

--- a/e2e/utils/strategy/CreateStrategyDriver.ts
+++ b/e2e/utils/strategy/CreateStrategyDriver.ts
@@ -1,5 +1,9 @@
 import { Page } from '@playwright/test';
-import { CreateStrategyTemplate } from './../../utils/strategy/template';
+import {
+  CreateStrategyTemplate,
+  assertDebugToken,
+  debugTokens,
+} from './../../utils/strategy/template';
 import { waitModalClose, waitModalOpen } from '../modal';
 
 export interface RecurringStrategyTestCase extends CreateStrategyTemplate {
@@ -51,10 +55,12 @@ export class CreateStrategyDriver {
   }
 
   async selectToken(tokenType: 'base' | 'quote') {
-    const token = this.testCase[tokenType];
+    const symbol = this.testCase[tokenType];
+    assertDebugToken(symbol);
+    const token = debugTokens[symbol];
     await this.page.getByTestId(`select-${tokenType}-token`).click();
     await waitModalOpen(this.page);
-    await this.page.getByLabel('Select Token').fill(token);
+    await this.page.getByLabel('Select Token').fill(symbol);
     await this.page.getByTestId(`select-token-${token}`).click();
     await waitModalClose(this.page);
   }

--- a/e2e/utils/strategy/template.ts
+++ b/e2e/utils/strategy/template.ts
@@ -3,18 +3,30 @@ import {
   getSellMin,
 } from '../../../src/components/strategies/overlapping/utils';
 
-type DebugTokens =
-  | 'USDC'
-  | 'DAI'
-  | 'BNT'
-  | 'PARQ'
-  | 'WBTC'
-  | 'BNB'
-  | 'MATIC'
-  | 'SHIB'
-  | 'UNI'
-  | 'USDT'
-  | 'ETH';
+export const debugTokens = {
+  BNB: '0x418D75f65a02b3D53B2418FB8E1fe493759c7605',
+  BNT: '0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C',
+  DAI: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+  ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+  MATIC: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
+  SHIB: '0xfcaF0e4498E78d65526a507360F755178b804Ba8',
+  UNI: '0x2730d6FdC86C95a74253BefFaA8306B40feDecbb',
+  USDT: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+  USDC: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  WBTC: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+};
+
+export function assertDebugToken(
+  symbol: string
+): asserts symbol is DebugTokens {
+  const tokenList = Object.keys(debugTokens);
+  if (!tokenList.includes(symbol)) {
+    const msg = `Only use token from this list ${tokenList.join()}, got ${symbol}`;
+    throw new Error(msg);
+  }
+}
+
+type DebugTokens = keyof typeof debugTokens;
 
 interface RangeOrder {
   min: string;

--- a/src/libs/modals/modals/ModalTokenList/ModalTokenListContent.tsx
+++ b/src/libs/modals/modals/ModalTokenList/ModalTokenListContent.tsx
@@ -110,7 +110,7 @@ export const ModalTokenListContent: FC<Props> = ({
                 <button
                   onClick={() => onSelect(token)}
                   className="flex flex-1 items-center gap-10 p-8"
-                  data-testid={`select-token-${token.symbol}`}
+                  data-testid={`select-token-${token.address}`}
                 >
                   <LogoImager
                     src={token.logoURI}


### PR DESCRIPTION
Use addresses instead of symbol for token selection.
We currently limit the tokens to the list in debug. This can be extended later.