### PR TITLE
using sync functions of the SDK for overlapping flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.0.0-0",
-    "@bancor/carbon-sdk": "^0.0.94-DEV",
+    "@bancor/carbon-sdk": "^0.0.95-DEV",
     "@cloudflare/workers-types": "^4.20230717.0",
     "@coinbase/wallet-sdk": "^3.6.3",
     "@ethersproject/abi": "^5.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { CreateStrategyCTAMobile } from 'components/strategies/create/CreateStrategyCTA';
-import { lazy, useEffect } from 'react';
+import { useEffect } from 'react';
 import { NotificationAlerts } from 'libs/notifications';
 import { ModalProvider } from 'libs/modals';
 import { useCarbonInit } from 'hooks/useCarbonInit';
@@ -7,18 +7,6 @@ import { MainMenu, MobileMenu } from 'components/core/menu';
 import { MainContent } from 'components/core/MainContent';
 import { useStore } from 'store';
 import { Toaster } from 'components/common/Toaster/Toaster';
-
-const TanStackRouterDevtools =
-  process.env.NODE_ENV === 'production'
-    ? () => null // Render nothing in production
-    : lazy(() =>
-        // Lazy load in development
-        import('@tanstack/router-devtools').then((res) => ({
-          default: res.TanStackRouterDevtools,
-          // For Embedded Mode
-          // default: res.TanStackRouterDevtoolsPanel
-        }))
-      );
 
 let didInit = false;
 
@@ -48,7 +36,6 @@ export const App = () => {
       <MainMenu />
       <main className="my-80 flex w-full flex-grow flex-col">
         <MainContent />
-        <TanStackRouterDevtools position="bottom-right" />
       </main>
       <MobileMenu />
       <ModalProvider />

--- a/src/components/debug/DebugCreateStrategy.tsx
+++ b/src/components/debug/DebugCreateStrategy.tsx
@@ -12,13 +12,12 @@ import { wait } from 'utils/helpers';
 import { useMemo, useRef, useState } from 'react';
 import { useWeb3 } from 'libs/web3';
 import { useQueryClient } from '@tanstack/react-query';
-import { useApproval } from 'hooks/useApproval';
 import { useModal } from 'hooks/useModal';
 import { Input, Label } from 'components/common/inputField';
 import { Checkbox } from 'components/common/Checkbox/Checkbox';
 import { useFiatCurrency } from 'hooks/useFiatCurrency';
-import { carbonSDK } from 'libs/sdk';
 import { getMarketPrice } from 'hooks/useMarketPrice';
+import { calculateOverlappingPrices } from '@bancor/carbon-sdk/strategy-management';
 
 const TOKENS = FAUCET_TOKENS.map((tkn) => ({
   address: tkn.tokenContract,
@@ -127,8 +126,7 @@ export const DebugCreateStrategy = () => {
     };
     if (spread) {
       const price = await getMarketPrice(base, quote, selectedFiatCurrency);
-      const params = await carbonSDK.calculateOverlappingStrategyPrices(
-        quote.address,
+      const params = calculateOverlappingPrices(
         buyMin,
         sellMax,
         price.toString(),

--- a/src/components/strategies/create/overlapping/CreateOverlappingStrategy.tsx
+++ b/src/components/strategies/create/overlapping/CreateOverlappingStrategy.tsx
@@ -89,16 +89,21 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
   ) => {
     if (!base || !quote) return;
     if (!sellBudget) return order0.setBudget('');
-    const buyBudget = calculateOverlappingBuyBudget(
-      base.decimals,
-      quote.decimals,
-      buyMin,
-      sellMax,
-      marketPrice.toString(),
-      spread.toString(),
-      sellBudget
-    );
-    order0.setBudget(buyBudget);
+    try {
+      const buyBudget = calculateOverlappingBuyBudget(
+        base.decimals,
+        quote.decimals,
+        buyMin,
+        sellMax,
+        marketPrice.toString(),
+        spread.toString(),
+        sellBudget
+      );
+      order0.setBudget(buyBudget);
+    } catch (e) {
+      console.error(e);
+      order0.setBudget('');
+    }
   };
 
   const setSellBudget = (
@@ -108,16 +113,21 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
   ) => {
     if (!base || !quote) return;
     if (!buyBudget) return order1.setBudget('');
-    const sellBudget = calculateOverlappingSellBudget(
-      base.decimals,
-      quote.decimals,
-      buyMin,
-      sellMax,
-      marketPrice.toString(),
-      spread.toString(),
-      buyBudget
-    );
-    order1.setBudget(sellBudget);
+    try {
+      const sellBudget = calculateOverlappingSellBudget(
+        base.decimals,
+        quote.decimals,
+        buyMin,
+        sellMax,
+        marketPrice.toString(),
+        spread.toString(),
+        buyBudget
+      );
+      order1.setBudget(sellBudget);
+    } catch (e) {
+      console.error(e);
+      order1.setBudget('');
+    }
   };
 
   // Initialize order when market price is available

--- a/src/components/strategies/create/overlapping/CreateOverlappingStrategy.tsx
+++ b/src/components/strategies/create/overlapping/CreateOverlappingStrategy.tsx
@@ -11,8 +11,11 @@ import { useMarketPrice } from 'hooks/useMarketPrice';
 import { OverlappingStrategyGraph } from 'components/strategies/overlapping/OverlappingStrategyGraph';
 import { OverlappingStrategySpread } from 'components/strategies/overlapping/OverlappingStrategySpread';
 import { CreateOverlappingRange } from './CreateOverlappingRange';
-import { carbonSDK } from 'libs/sdk';
-import { Toolkit } from '@bancor/carbon-sdk/strategy-management';
+import {
+  calculateOverlappingBuyBudget,
+  calculateOverlappingPrices,
+  calculateOverlappingSellBudget,
+} from '@bancor/carbon-sdk/strategy-management';
 import {
   getMaxBuyMin,
   getMinSellMax,
@@ -34,15 +37,6 @@ export interface OverlappingStrategyProps {
   spread: number;
   setSpread: Dispatch<SetStateAction<number>>;
 }
-type FromPromise<T> = T extends Promise<infer I> ? I : never;
-type StrategyPrices = FromPromise<
-  ReturnType<Toolkit['calculateOverlappingStrategyPrices']>
->;
-
-export type SetOverlappingParams = (
-  min: string,
-  max: string
-) => Promise<StrategyPrices | undefined>;
 
 const getInitialPrice = (marketPrice: string | number, quote: Token) => {
   const currentPrice = new SafeDecimal(marketPrice);
@@ -72,9 +66,8 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
     buy: true,
   });
 
-  const setOverlappingParams = async (min: string, max: string) => {
-    const params = await carbonSDK.calculateOverlappingStrategyPrices(
-      quote!.address,
+  const setOverlappingParams = (min: string, max: string) => {
+    const params = calculateOverlappingPrices(
       min,
       max,
       marketPrice.toString(),
@@ -89,16 +82,16 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
     return params;
   };
 
-  const setBuyBudget = async (
+  const setBuyBudget = (
     sellBudget: string,
     buyMin: string,
     sellMax: string
   ) => {
     if (!base || !quote) return;
     if (!sellBudget) return order0.setBudget('');
-    const buyBudget = await carbonSDK.calculateOverlappingStrategyBuyBudget(
-      base.address,
-      quote.address,
+    const buyBudget = calculateOverlappingBuyBudget(
+      base.decimals,
+      quote.decimals,
       buyMin,
       sellMax,
       marketPrice.toString(),
@@ -108,16 +101,16 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
     order0.setBudget(buyBudget);
   };
 
-  const setSellBudget = async (
+  const setSellBudget = (
     buyBudget: string,
     buyMin: string,
     sellMax: string
   ) => {
     if (!base || !quote) return;
     if (!buyBudget) return order1.setBudget('');
-    const sellBudget = await carbonSDK.calculateOverlappingStrategySellBudget(
-      base.address,
-      quote.address,
+    const sellBudget = calculateOverlappingSellBudget(
+      base.decimals,
+      quote.decimals,
       buyMin,
       sellMax,
       marketPrice.toString(),
@@ -137,20 +130,19 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
       const min = order0.min;
       const max = order1.max;
       if (isValidRange(min, max) && isValidSpread(spread)) {
-        setOverlappingParams(min, max).then((params) => {
-          const buyOrder = { min, marginalPrice: params.buyPriceMarginal };
-          const sellOrder = { max, marginalPrice: params.sellPriceMarginal };
-          if (isMinAboveMarket(buyOrder, quote)) {
-            setAnchoredOrder('sell');
-            setBuyBudget(order1.budget, min, max);
-          } else if (isMaxBelowMarket(sellOrder, quote)) {
-            setAnchoredOrder('buy');
-            setSellBudget(order0.budget, min, max);
-          } else {
-            if (anchoredOrder === 'buy') setSellBudget(order0.budget, min, max);
-            if (anchoredOrder === 'sell') setBuyBudget(order1.budget, min, max);
-          }
-        });
+        const params = setOverlappingParams(min, max);
+        const buyOrder = { min, marginalPrice: params.buyPriceMarginal };
+        const sellOrder = { max, marginalPrice: params.sellPriceMarginal };
+        if (isMinAboveMarket(buyOrder, quote)) {
+          setAnchoredOrder('sell');
+          setBuyBudget(order1.budget, min, max);
+        } else if (isMaxBelowMarket(sellOrder, quote)) {
+          setAnchoredOrder('buy');
+          setSellBudget(order0.budget, min, max);
+        } else {
+          if (anchoredOrder === 'buy') setSellBudget(order0.budget, min, max);
+          if (anchoredOrder === 'sell') setBuyBudget(order1.budget, min, max);
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -162,16 +154,15 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
     const max = order1.max;
     if (!min) return;
     if (isValidRange(min, max) && isValidSpread(spread)) {
-      setOverlappingParams(min, max).then((params) => {
-        const marginalPrice = params.buyPriceMarginal;
-        if (isMinAboveMarket({ min, marginalPrice }, quote)) {
-          setAnchoredOrder('sell');
-          setBuyBudget(order1.budget, min, max);
-        } else {
-          if (anchoredOrder === 'buy') setSellBudget(order0.budget, min, max);
-          if (anchoredOrder === 'sell') setBuyBudget(order1.budget, min, max);
-        }
-      });
+      const params = setOverlappingParams(min, max);
+      const marginalPrice = params.buyPriceMarginal;
+      if (isMinAboveMarket({ min, marginalPrice }, quote)) {
+        setAnchoredOrder('sell');
+        setBuyBudget(order1.budget, min, max);
+      } else {
+        if (anchoredOrder === 'buy') setSellBudget(order0.budget, min, max);
+        if (anchoredOrder === 'sell') setBuyBudget(order1.budget, min, max);
+      }
     }
     const timeout = setTimeout(async () => {
       const decimals = quote?.decimals ?? 18;
@@ -190,16 +181,15 @@ export const CreateOverlappingStrategy: FC<OverlappingStrategyProps> = (
     const max = order1.max;
     if (!max) return;
     if (isValidRange(min, max) && isValidSpread(spread)) {
-      setOverlappingParams(min, max).then((params) => {
-        const marginalPrice = params.sellPriceMarginal;
-        if (isMaxBelowMarket({ max, marginalPrice }, quote)) {
-          setAnchoredOrder('buy');
-          setSellBudget(order0.budget, min, max);
-        } else {
-          if (anchoredOrder === 'buy') setSellBudget(order0.budget, min, max);
-          if (anchoredOrder === 'sell') setBuyBudget(order1.budget, min, max);
-        }
-      });
+      const params = setOverlappingParams(min, max);
+      const marginalPrice = params.sellPriceMarginal;
+      if (isMaxBelowMarket({ max, marginalPrice }, quote)) {
+        setAnchoredOrder('buy');
+        setSellBudget(order0.budget, min, max);
+      } else {
+        if (anchoredOrder === 'buy') setSellBudget(order0.budget, min, max);
+        if (anchoredOrder === 'sell') setBuyBudget(order1.budget, min, max);
+      }
     }
     const timeout = setTimeout(async () => {
       const decimals = quote?.decimals ?? 18;

--- a/src/components/strategies/edit/overlapping/DepositOverlappingStrategy.tsx
+++ b/src/components/strategies/edit/overlapping/DepositOverlappingStrategy.tsx
@@ -16,8 +16,11 @@ import { ReactComponent as IconLink } from 'assets/icons/link.svg';
 import { SafeDecimal } from 'libs/safedecimal';
 import { BudgetInput } from 'components/strategies/common/BudgetInput';
 import { DepositAllocatedBudget } from 'components/strategies/common/AllocatedBudget';
-import { carbonSDK } from 'libs/sdk';
-import { MarginalPriceOptions } from '@bancor/carbon-sdk/strategy-management';
+import {
+  MarginalPriceOptions,
+  calculateOverlappingBuyBudget,
+  calculateOverlappingSellBudget,
+} from '@bancor/carbon-sdk/strategy-management';
 import { MarketWarning } from './MarketWarning';
 import { geoMean } from 'utils/fullOutcome';
 
@@ -65,42 +68,40 @@ export const DepositOverlappingStrategy: FC<Props> = (props) => {
     return oldMarketPrice.toString();
   };
 
-  const setBuyBudget = async (sellBudgetDelta: string) => {
+  const setBuyBudget = (sellBudgetDelta: string) => {
     if (!sellBudgetDelta) return order0.setBudget('');
     const sellBudget = new SafeDecimal(sellBudgetDelta || '0').plus(
       strategy.order1.balance || '0'
     );
-    const resultBuyBudget =
-      await carbonSDK.calculateOverlappingStrategyBuyBudget(
-        base.address,
-        quote.address,
-        order0.min,
-        order1.max,
-        getMarketPrice(),
-        spread.toString(),
-        sellBudget.toString()
-      );
+    const resultBuyBudget = calculateOverlappingBuyBudget(
+      base.decimals,
+      quote.decimals,
+      order0.min,
+      order1.max,
+      getMarketPrice(),
+      spread.toString(),
+      sellBudget.toString()
+    );
     const buyBudget = new SafeDecimal(resultBuyBudget).minus(
       strategy.order0.balance || '0'
     );
     order0.setBudget(buyBudget.toString());
   };
 
-  const setSellBudget = async (buyBudgetDelta: string) => {
+  const setSellBudget = (buyBudgetDelta: string) => {
     if (!buyBudgetDelta) return order1.setBudget('');
     const buyBudget = new SafeDecimal(buyBudgetDelta || '0').plus(
       strategy.order0.balance || '0'
     );
-    const resultSellBudget =
-      await carbonSDK.calculateOverlappingStrategySellBudget(
-        base.address,
-        quote.address,
-        order0.min,
-        order1.max,
-        getMarketPrice(),
-        spread.toString(),
-        buyBudget.toString()
-      );
+    const resultSellBudget = calculateOverlappingSellBudget(
+      base.decimals,
+      quote.decimals,
+      order0.min,
+      order1.max,
+      getMarketPrice(),
+      spread.toString(),
+      buyBudget.toString()
+    );
     const sellBudget = new SafeDecimal(resultSellBudget).minus(
       strategy.order1.balance || '0'
     );

--- a/src/components/strategies/edit/overlapping/DepositOverlappingStrategy.tsx
+++ b/src/components/strategies/edit/overlapping/DepositOverlappingStrategy.tsx
@@ -73,19 +73,24 @@ export const DepositOverlappingStrategy: FC<Props> = (props) => {
     const sellBudget = new SafeDecimal(sellBudgetDelta || '0').plus(
       strategy.order1.balance || '0'
     );
-    const resultBuyBudget = calculateOverlappingBuyBudget(
-      base.decimals,
-      quote.decimals,
-      order0.min,
-      order1.max,
-      getMarketPrice(),
-      spread.toString(),
-      sellBudget.toString()
-    );
-    const buyBudget = new SafeDecimal(resultBuyBudget).minus(
-      strategy.order0.balance || '0'
-    );
-    order0.setBudget(buyBudget.toString());
+    try {
+      const resultBuyBudget = calculateOverlappingBuyBudget(
+        base.decimals,
+        quote.decimals,
+        order0.min,
+        order1.max,
+        getMarketPrice(),
+        spread.toString(),
+        sellBudget.toString()
+      );
+      const buyBudget = new SafeDecimal(resultBuyBudget).minus(
+        strategy.order0.balance || '0'
+      );
+      order0.setBudget(buyBudget.toString());
+    } catch (e) {
+      console.error(e);
+      order0.setBudget('');
+    }
   };
 
   const setSellBudget = (buyBudgetDelta: string) => {
@@ -93,19 +98,24 @@ export const DepositOverlappingStrategy: FC<Props> = (props) => {
     const buyBudget = new SafeDecimal(buyBudgetDelta || '0').plus(
       strategy.order0.balance || '0'
     );
-    const resultSellBudget = calculateOverlappingSellBudget(
-      base.decimals,
-      quote.decimals,
-      order0.min,
-      order1.max,
-      getMarketPrice(),
-      spread.toString(),
-      buyBudget.toString()
-    );
-    const sellBudget = new SafeDecimal(resultSellBudget).minus(
-      strategy.order1.balance || '0'
-    );
-    order1.setBudget(sellBudget.toString());
+    try {
+      const resultSellBudget = calculateOverlappingSellBudget(
+        base.decimals,
+        quote.decimals,
+        order0.min,
+        order1.max,
+        getMarketPrice(),
+        spread.toString(),
+        buyBudget.toString()
+      );
+      const sellBudget = new SafeDecimal(resultSellBudget).minus(
+        strategy.order1.balance || '0'
+      );
+      order1.setBudget(sellBudget.toString());
+    } catch (e) {
+      console.error(e);
+      order1.setBudget('');
+    }
   };
 
   const checkInsufficientBalance = (balance: string, order: OrderCreate) => {

--- a/src/components/strategies/edit/overlapping/EditPriceOverlappingStrategy.tsx
+++ b/src/components/strategies/edit/overlapping/EditPriceOverlappingStrategy.tsx
@@ -70,16 +70,21 @@ export const EditPriceOverlappingStrategy: FC<Props> = (props) => {
   ) => {
     if (!base || !quote) return;
     if (!sellBudget) return order0.setBudget('');
-    const buyBudget = calculateOverlappingBuyBudget(
-      base.decimals,
-      quote.decimals,
-      buyMin,
-      sellMax,
-      marketPrice.toString(),
-      spread.toString(),
-      sellBudget
-    );
-    order0.setBudget(buyBudget);
+    try {
+      const buyBudget = calculateOverlappingBuyBudget(
+        base.decimals,
+        quote.decimals,
+        buyMin,
+        sellMax,
+        marketPrice.toString(),
+        spread.toString(),
+        sellBudget
+      );
+      order0.setBudget(buyBudget);
+    } catch (e) {
+      console.error(e);
+      order0.setBudget('');
+    }
   };
 
   const setSellBudget = (
@@ -89,16 +94,21 @@ export const EditPriceOverlappingStrategy: FC<Props> = (props) => {
   ) => {
     if (!base || !quote) return;
     if (!buyBudget) order1.setBudget('');
-    const sellBudget = calculateOverlappingSellBudget(
-      base.decimals,
-      quote.decimals,
-      buyMin,
-      sellMax,
-      marketPrice.toString(),
-      spread.toString(),
-      buyBudget
-    );
-    order1.setBudget(sellBudget);
+    try {
+      const sellBudget = calculateOverlappingSellBudget(
+        base.decimals,
+        quote.decimals,
+        buyMin,
+        sellMax,
+        marketPrice.toString(),
+        spread.toString(),
+        buyBudget
+      );
+      order1.setBudget(sellBudget);
+    } catch (e) {
+      console.error(e);
+      order1.setBudget('');
+    }
   };
 
   // Initialize order when market price is available

--- a/src/components/strategies/edit/overlapping/WithdrawOverlappingStrategy.tsx
+++ b/src/components/strategies/edit/overlapping/WithdrawOverlappingStrategy.tsx
@@ -100,19 +100,24 @@ export const WithdrawOverlappingStrategy: FC<Props> = (props) => {
     const sellBudget = new SafeDecimal(strategy.order1.balance || '0').minus(
       sellBudgetDelta || '0'
     );
-    const resultBuyBudget = calculateOverlappingBuyBudget(
-      base.decimals,
-      quote.decimals,
-      order0.min,
-      order1.max,
-      getMarketPrice(),
-      spread.toString(),
-      sellBudget.toString()
-    );
-    const buyBudget = new SafeDecimal(strategy.order0.balance || '0').minus(
-      resultBuyBudget
-    );
-    order0.setBudget(buyBudget.lt(0) ? '0' : buyBudget.toString());
+    try {
+      const resultBuyBudget = calculateOverlappingBuyBudget(
+        base.decimals,
+        quote.decimals,
+        order0.min,
+        order1.max,
+        getMarketPrice(),
+        spread.toString(),
+        sellBudget.toString()
+      );
+      const buyBudget = new SafeDecimal(strategy.order0.balance || '0').minus(
+        resultBuyBudget
+      );
+      order0.setBudget(buyBudget.lt(0) ? '0' : buyBudget.toString());
+    } catch (e) {
+      console.error(e);
+      order0.setBudget('');
+    }
   };
 
   const setSellBudget = async (buyBudgetDelta: string) => {
@@ -120,19 +125,24 @@ export const WithdrawOverlappingStrategy: FC<Props> = (props) => {
     const buyBudget = new SafeDecimal(strategy.order0.balance || '0').minus(
       buyBudgetDelta || '0'
     );
-    const resultSellBudget = calculateOverlappingSellBudget(
-      base.decimals,
-      quote.decimals,
-      order0.min,
-      order1.max,
-      getMarketPrice(),
-      spread.toString(),
-      buyBudget.toString()
-    );
-    const sellBudget = new SafeDecimal(strategy.order1.balance || '0').minus(
-      resultSellBudget
-    );
-    order1.setBudget(sellBudget.lt(0) ? '0' : sellBudget.toString());
+    try {
+      const resultSellBudget = calculateOverlappingSellBudget(
+        base.decimals,
+        quote.decimals,
+        order0.min,
+        order1.max,
+        getMarketPrice(),
+        spread.toString(),
+        buyBudget.toString()
+      );
+      const sellBudget = new SafeDecimal(strategy.order1.balance || '0').minus(
+        resultSellBudget
+      );
+      order1.setBudget(sellBudget.lt(0) ? '0' : sellBudget.toString());
+    } catch (e) {
+      console.error(e);
+      order1.setBudget('');
+    }
   };
 
   const onBuyBudgetChange = (value: string) => {

--- a/src/components/strategies/edit/overlapping/WithdrawOverlappingStrategy.tsx
+++ b/src/components/strategies/edit/overlapping/WithdrawOverlappingStrategy.tsx
@@ -17,8 +17,11 @@ import { ReactComponent as IconWarning } from 'assets/icons/warning.svg';
 import { SafeDecimal } from 'libs/safedecimal';
 import { BudgetInput } from 'components/strategies/common/BudgetInput';
 import { WithdrawAllocatedBudget } from 'components/strategies/common/AllocatedBudget';
-import { carbonSDK } from 'libs/sdk';
-import { MarginalPriceOptions } from '@bancor/carbon-sdk/strategy-management';
+import {
+  MarginalPriceOptions,
+  calculateOverlappingBuyBudget,
+  calculateOverlappingSellBudget,
+} from '@bancor/carbon-sdk/strategy-management';
 import { geoMean } from 'utils/fullOutcome';
 
 interface Props {
@@ -92,21 +95,20 @@ export const WithdrawOverlappingStrategy: FC<Props> = (props) => {
     return oldMarketPrice.toString();
   };
 
-  const setBuyBudget = async (sellBudgetDelta: string) => {
+  const setBuyBudget = (sellBudgetDelta: string) => {
     if (!sellBudgetDelta) return order0.setBudget('');
     const sellBudget = new SafeDecimal(strategy.order1.balance || '0').minus(
       sellBudgetDelta || '0'
     );
-    const resultBuyBudget =
-      await carbonSDK.calculateOverlappingStrategyBuyBudget(
-        base.address,
-        quote.address,
-        order0.min,
-        order1.max,
-        getMarketPrice(),
-        spread.toString(),
-        sellBudget.toString()
-      );
+    const resultBuyBudget = calculateOverlappingBuyBudget(
+      base.decimals,
+      quote.decimals,
+      order0.min,
+      order1.max,
+      getMarketPrice(),
+      spread.toString(),
+      sellBudget.toString()
+    );
     const buyBudget = new SafeDecimal(strategy.order0.balance || '0').minus(
       resultBuyBudget
     );
@@ -118,16 +120,15 @@ export const WithdrawOverlappingStrategy: FC<Props> = (props) => {
     const buyBudget = new SafeDecimal(strategy.order0.balance || '0').minus(
       buyBudgetDelta || '0'
     );
-    const resultSellBudget =
-      await carbonSDK.calculateOverlappingStrategySellBudget(
-        base.address,
-        quote.address,
-        order0.min,
-        order1.max,
-        getMarketPrice(),
-        spread.toString(),
-        buyBudget.toString()
-      );
+    const resultSellBudget = calculateOverlappingSellBudget(
+      base.decimals,
+      quote.decimals,
+      order0.min,
+      order1.max,
+      getMarketPrice(),
+      spread.toString(),
+      buyBudget.toString()
+    );
     const sellBudget = new SafeDecimal(strategy.order1.balance || '0').minus(
       resultSellBudget
     );

--- a/src/workers/sdk.ts
+++ b/src/workers/sdk.ts
@@ -376,15 +376,6 @@ const sdkExposed = {
     sdkCache.getLatestTradeByPair(source, target),
   getMaxSourceAmountByPair: (source: string, target: string) =>
     carbonSDK.getMaxSourceAmountByPair(source, target),
-  calculateOverlappingStrategyPrices: ((...params) => {
-    return carbonSDK.calculateOverlappingStrategyPrices(...params);
-  }) as Toolkit['calculateOverlappingStrategyPrices'],
-  calculateOverlappingStrategyBuyBudget: ((...params) => {
-    return carbonSDK.calculateOverlappingStrategyBuyBudget(...params);
-  }) as Toolkit['calculateOverlappingStrategyBuyBudget'],
-  calculateOverlappingStrategySellBudget: ((...params) => {
-    return carbonSDK.calculateOverlappingStrategySellBudget(...params);
-  }) as Toolkit['calculateOverlappingStrategySellBudget'],
 };
 
 export type CarbonSDKWebWorker = typeof sdkExposed;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,10 +1294,10 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@bancor/carbon-sdk@^0.0.94-DEV":
-  version "0.0.94-DEV"
-  resolved "https://registry.yarnpkg.com/@bancor/carbon-sdk/-/carbon-sdk-0.0.94-DEV.tgz#8e66182e4802b95025c43bbe9caaf57c2f66192d"
-  integrity sha512-HPGdZEcv/yz/R5X2q8JeNHZ/Mw59TFuGkHNCUatvFkqoF+R1ex+eoSTsMCd+1K+JBbTlyi924B/KE9rBIOkcJA==
+"@bancor/carbon-sdk@^0.0.95-DEV":
+  version "0.0.95-DEV"
+  resolved "https://registry.yarnpkg.com/@bancor/carbon-sdk/-/carbon-sdk-0.0.95-DEV.tgz#42fabd817588e50b63949acdcfe021b925f5b494"
+  integrity sha512-U6L4GpLAymhjWCXMREJC+J9YTlVuRuPGOLxnMD1+EbDh4WXSUZS1f9+TiocrC2I7o3fDXVOqpuILuDjcRQw81A==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/bignumber" "^5.7.0"


### PR DESCRIPTION
This PR makes use of the latest version of the SDK in which breaking change was introduced to calculate overlapping prices - namely not requiring the quote token address and not limiting prices to a 1 wei resolution.

Switched over the app to use sync functions instead of async - given that the app has the token decimals to provide.