### PR TITLE
[E2E] Reduce flakiness

### DIFF
--- a/e2e/pages/strategy.spec.ts
+++ b/e2e/pages/strategy.spec.ts
@@ -561,7 +561,7 @@ const testDescription = (testCase: CreateStrategyTestCase) => {
 
 test.describe('Strategies', () => {
   test.beforeEach(async ({ page }, testInfo) => {
-    testInfo.setTimeout(90_000);
+    testInfo.setTimeout(120_000);
     await setupFork(testInfo);
     const debug = new DebugDriver(page);
     await debug.visit();

--- a/e2e/pages/trade.spec.ts
+++ b/e2e/pages/trade.spec.ts
@@ -4,7 +4,7 @@ import { mockApi } from '../utils/mock-api';
 import { DebugDriver, removeFork, setupFork } from '../utils/DebugDriver';
 import { TradeDriver } from '../utils/TradeDriver';
 import { navigateTo } from '../utils/operators';
-import { checkApproval } from '../utils/modal';
+import { TokenApprovalDriver } from '../utils/TokenApprovalDriver';
 
 test.describe('Trade', () => {
   test.beforeEach(async ({ page }, testInfo) => {
@@ -71,7 +71,8 @@ test.describe('Trade', () => {
       await driver.submit();
 
       // Token approval
-      await checkApproval(page, [testCase.source]);
+      const tokenApproval = new TokenApprovalDriver(page);
+      await tokenApproval.checkApproval([testCase.source]);
 
       // Verify form empty
       expect(driver.getPayInput()).toHaveValue('');

--- a/e2e/pages/trade.spec.ts
+++ b/e2e/pages/trade.spec.ts
@@ -5,7 +5,6 @@ import { DebugDriver, removeFork, setupFork } from '../utils/DebugDriver';
 import { TradeDriver } from '../utils/TradeDriver';
 import { navigateTo } from '../utils/operators';
 import { checkApproval } from '../utils/modal';
-import { NotificationDriver } from '../utils/NotificationDriver';
 
 test.describe('Trade', () => {
   test.beforeEach(async ({ page }, testInfo) => {
@@ -73,15 +72,6 @@ test.describe('Trade', () => {
 
       // Token approval
       await checkApproval(page, [testCase.source]);
-
-      // Verify notification
-      const notificationDriver = new NotificationDriver(page);
-      const notif = notificationDriver.getNotification('trade');
-      await expect(notif.title()).toHaveText('Success', { timeout: 10_000 });
-      await expect(notif.description()).toHaveText(
-        `Trading ${sourceValue} ${source} for ${target} was successfully completed.`,
-        { timeout: 10_000 }
-      );
 
       // Verify form empty
       expect(driver.getPayInput()).toHaveValue('');

--- a/e2e/tests/strategy/disposable/create.ts
+++ b/e2e/tests/strategy/disposable/create.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import { checkApproval } from '../../../utils/modal';
 import { NotificationDriver } from '../../../utils/NotificationDriver';
 import { navigateTo, screenshot, waitFor } from '../../../utils/operators';
 import {
@@ -9,6 +8,7 @@ import {
   assertDisposableTestCase,
   screenshotPath,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const create = (testCase: CreateStrategyTestCase) => {
   assertDisposableTestCase(testCase);
@@ -35,10 +35,11 @@ export const create = (testCase: CreateStrategyTestCase) => {
 
     await createForm.submit();
 
+    const tokenApproval = new TokenApprovalDriver(page);
     if (direction === 'buy') {
-      await checkApproval(page, [quote]);
+      await tokenApproval.checkApproval([quote]);
     } else {
-      await checkApproval(page, [base]);
+      await tokenApproval.checkApproval([base]);
     }
 
     await page.waitForURL('/', { timeout: 10_000 });

--- a/e2e/tests/strategy/disposable/delete.ts
+++ b/e2e/tests/strategy/disposable/delete.ts
@@ -5,11 +5,13 @@ import {
 } from './../../../utils/strategy';
 import { waitModalOpen } from './../../../utils/modal';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const deleteStrategy = (testCase: CreateStrategyTestCase) => {
   return test('Delete', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('deleteStrategy');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/disposable/deposit.ts
+++ b/e2e/tests/strategy/disposable/deposit.ts
@@ -5,6 +5,7 @@ import {
   CreateStrategyTestCase,
   EditStrategyDriver,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const deposit = (testCase: CreateStrategyTestCase) => {
   assertDisposableTestCase(testCase);
@@ -12,7 +13,8 @@ export const deposit = (testCase: CreateStrategyTestCase) => {
   const output = testCase.output.deposit;
   return test('Deposit', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('depositFunds');
 
     const edit = new EditStrategyDriver(page, testCase);

--- a/e2e/tests/strategy/disposable/deposit.ts
+++ b/e2e/tests/strategy/disposable/deposit.ts
@@ -17,6 +17,7 @@ export const deposit = (testCase: CreateStrategyTestCase) => {
 
     const edit = new EditStrategyDriver(page, testCase);
     await edit.waitForPage('deposit');
+    await edit.waitForWallet();
     await edit.fillDisposableBudget('deposit');
 
     await edit.submit('deposit');

--- a/e2e/tests/strategy/disposable/duplicate.ts
+++ b/e2e/tests/strategy/disposable/duplicate.ts
@@ -6,6 +6,7 @@ import {
 } from './../../../utils/strategy';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
 import { waitModalOpen } from '../../../utils/modal';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const duplicate = (testCase: CreateStrategyTestCase) => {
   assertDisposableTestCase(testCase);
@@ -14,7 +15,8 @@ export const duplicate = (testCase: CreateStrategyTestCase) => {
 
   return test('Duplicate', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('duplicateStrategy');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/disposable/edit.ts
+++ b/e2e/tests/strategy/disposable/edit.ts
@@ -5,6 +5,7 @@ import {
   CreateStrategyTestCase,
   EditStrategyDriver,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const editPrice = (testCase: CreateStrategyTestCase) => {
   assertDisposableTestCase(testCase);
@@ -12,7 +13,8 @@ export const editPrice = (testCase: CreateStrategyTestCase) => {
   const output = testCase.output.editPrice;
   return test('Edit Price', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('editPrices');
 
     const edit = new EditStrategyDriver(page, testCase);

--- a/e2e/tests/strategy/disposable/edit.ts
+++ b/e2e/tests/strategy/disposable/edit.ts
@@ -17,7 +17,7 @@ export const editPrice = (testCase: CreateStrategyTestCase) => {
 
     const edit = new EditStrategyDriver(page, testCase);
     await edit.waitForPage('editPrices');
-    await edit.fillDisposablePrice();
+    await edit.fillDisposablePrice('editPrices');
 
     await edit.submit('editPrices');
     await page.waitForURL('/', { timeout: 10_000 });

--- a/e2e/tests/strategy/disposable/withdraw.ts
+++ b/e2e/tests/strategy/disposable/withdraw.ts
@@ -6,6 +6,7 @@ import {
   CreateStrategyTestCase,
   EditStrategyDriver,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const withdraw = (testCase: CreateStrategyTestCase) => {
   assertDisposableTestCase(testCase);
@@ -13,7 +14,8 @@ export const withdraw = (testCase: CreateStrategyTestCase) => {
   const output = testCase.output.withdraw;
   return test('Withdraw', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('withdrawFunds');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/overlapping/create.ts
+++ b/e2e/tests/strategy/overlapping/create.ts
@@ -8,7 +8,7 @@ import {
   assertOverlappingTestCase,
   screenshotPath,
 } from '../../../utils/strategy';
-import { checkApproval } from '../../../utils/modal';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const createOverlappingStrategy = (testCase: CreateStrategyTestCase) => {
   assertOverlappingTestCase(testCase);
@@ -35,8 +35,9 @@ export const createOverlappingStrategy = (testCase: CreateStrategyTestCase) => {
     await createForm.fillOverlapping();
     expect(overlappingForm.max()).toHaveValue(sell.max.toString());
 
+    const tokenApproval = new TokenApprovalDriver(page);
     await createForm.submit();
-    await checkApproval(page, [base, quote]);
+    await tokenApproval.checkApproval([base, quote]);
     await page.waitForURL('/', { timeout: 10_000 });
 
     // Verify strategy data
@@ -51,12 +52,13 @@ export const createOverlappingStrategy = (testCase: CreateStrategyTestCase) => {
     await expect(strategy.budget('sell')).toHaveText(output.sell.budget);
     await expect(strategy.budgetFiat('sell')).toHaveText(output.sell.fiat);
 
-    const sellTooltip = await strategy.priceTooltip('sell');
+    const isOverlapping = true;
+    const sellTooltip = await strategy.priceTooltip('sell', { isOverlapping });
     await expect(sellTooltip.minPrice()).toHaveText(output.sell.min);
     await expect(sellTooltip.maxPrice()).toHaveText(output.sell.max);
     await sellTooltip.waitForDetached();
 
-    const buyTooltip = await strategy.priceTooltip('buy');
+    const buyTooltip = await strategy.priceTooltip('buy', { isOverlapping });
     await expect(buyTooltip.minPrice()).toHaveText(output.buy.min);
     await expect(buyTooltip.maxPrice()).toHaveText(output.buy.max);
     await buyTooltip.waitForDetached();

--- a/e2e/tests/strategy/recurring/create.ts
+++ b/e2e/tests/strategy/recurring/create.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import { checkApproval } from '../../../utils/modal';
 import { NotificationDriver } from '../../../utils/NotificationDriver';
 import { navigateTo, screenshot, waitFor } from '../../../utils/operators';
 import {
@@ -10,6 +9,7 @@ import {
   getRecurringSettings,
   screenshotPath,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const createRecurringStrategy = (testCase: CreateStrategyTestCase) => {
   assertRecurringTestCase(testCase);
@@ -36,9 +36,9 @@ export const createRecurringStrategy = (testCase: CreateStrategyTestCase) => {
     await expect(sellForm.outcomeValue()).toHaveText(output.sell.outcomeValue);
     await expect(sellForm.outcomeQuote()).toHaveText(output.sell.outcomeQuote);
 
+    const tokenApproval = new TokenApprovalDriver(page);
     await createForm.submit();
-
-    await checkApproval(page, [base, quote]);
+    await tokenApproval.checkApproval([base, quote]);
 
     await page.waitForURL('/', { timeout: 10_000 });
 

--- a/e2e/tests/strategy/recurring/delete.ts
+++ b/e2e/tests/strategy/recurring/delete.ts
@@ -5,11 +5,13 @@ import {
 } from './../../../utils/strategy';
 import { waitModalOpen } from './../../../utils/modal';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const deleteStrategyTest = (testCase: CreateStrategyTestCase) => {
   return test('Delete', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('deleteStrategy');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/recurring/deposit.ts
+++ b/e2e/tests/strategy/recurring/deposit.ts
@@ -5,13 +5,15 @@ import {
   CreateStrategyTestCase,
   EditStrategyDriver,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const depositStrategyTest = (testCase: CreateStrategyTestCase) => {
   assertRecurringTestCase(testCase);
   const { buy, sell } = testCase.output.deposit;
   return test('Deposit', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('depositFunds');
 
     const edit = new EditStrategyDriver(page, testCase);

--- a/e2e/tests/strategy/recurring/deposit.ts
+++ b/e2e/tests/strategy/recurring/deposit.ts
@@ -16,6 +16,7 @@ export const depositStrategyTest = (testCase: CreateStrategyTestCase) => {
 
     const edit = new EditStrategyDriver(page, testCase);
     await edit.waitForPage('deposit');
+    await edit.waitForWallet();
     await edit.fillRecurringBudget('deposit');
 
     await edit.submit('deposit');

--- a/e2e/tests/strategy/recurring/duplicate.ts
+++ b/e2e/tests/strategy/recurring/duplicate.ts
@@ -6,6 +6,7 @@ import {
 } from './../../../utils/strategy';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
 import { waitModalOpen } from '../../../utils/modal';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const duplicateStrategyTest = (testCase: CreateStrategyTestCase) => {
   const { base, quote } = testCase;
@@ -13,7 +14,8 @@ export const duplicateStrategyTest = (testCase: CreateStrategyTestCase) => {
   const { buy, sell, totalFiat } = testCase.output.create;
   return test('Duplicate', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('duplicateStrategy');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/recurring/edit.ts
+++ b/e2e/tests/strategy/recurring/edit.ts
@@ -7,13 +7,15 @@ import {
   getRecurringSettings,
   MyStrategyDriver,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const editPriceStrategyTest = (testCase: CreateStrategyTestCase) => {
   assertRecurringTestCase(testCase);
   return test('Edit Price', async ({ page }) => {
     const { buy, sell } = testCase.output.editPrice;
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('editPrices');
 
     const edit = new EditStrategyDriver(page, testCase);

--- a/e2e/tests/strategy/recurring/edit.ts
+++ b/e2e/tests/strategy/recurring/edit.ts
@@ -18,7 +18,7 @@ export const editPriceStrategyTest = (testCase: CreateStrategyTestCase) => {
 
     const edit = new EditStrategyDriver(page, testCase);
     await edit.waitForPage('editPrices');
-    await edit.fillRecurringPrice();
+    await edit.fillRecurringPrice('editPrices');
     await edit.submit('editPrices');
     await page.waitForURL('/', { timeout: 10_000 });
 

--- a/e2e/tests/strategy/recurring/pause.ts
+++ b/e2e/tests/strategy/recurring/pause.ts
@@ -3,13 +3,15 @@ import { waitModalOpen } from './../../../utils/modal';
 import { Page } from 'playwright-core';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
 import { CreateStrategyTestCase } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const pauseStrategy = async (
   page: Page,
   testCase: CreateStrategyTestCase
 ) => {
   const manage = new ManageStrategyDriver(page);
-  const strategy = await manage.createStrategy(testCase);
+  const tokenApproval = new TokenApprovalDriver(page);
+  const strategy = await manage.createStrategy(testCase, { tokenApproval });
   await strategy.clickManageEntry('pauseStrategy');
 
   const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/recurring/renew.ts
+++ b/e2e/tests/strategy/recurring/renew.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { pauseStrategy } from './pause';
-import { NotificationDriver } from './../../../utils/NotificationDriver';
 import {
   assertRecurringTestCase,
   CreateStrategyTestCase,
@@ -20,13 +19,6 @@ export const renewStrategyTest = (testCase: CreateStrategyTestCase) => {
     await edit.fillRecurringPrice('renew');
     await edit.submit('renew');
     await page.waitForURL('/', { timeout: 10_000 });
-
-    const notificationDriver = new NotificationDriver(page);
-    const notif = notificationDriver.getNotification('renew-strategy');
-    await expect(notif.title()).toHaveText('Success');
-    await expect(notif.description()).toHaveText(
-      'Your request to renew the strategy was successfully completed.'
-    );
 
     await expect(strategy.status()).toHaveText('Active');
     const myStrategies = new MyStrategyDriver(page);

--- a/e2e/tests/strategy/recurring/renew.ts
+++ b/e2e/tests/strategy/recurring/renew.ts
@@ -17,7 +17,7 @@ export const renewStrategyTest = (testCase: CreateStrategyTestCase) => {
     await strategy.clickManageEntry('renewStrategy');
     const edit = new EditStrategyDriver(page, testCase);
     await edit.waitForPage('renew');
-    await edit.fillRecurringPrice();
+    await edit.fillRecurringPrice('renew');
     await edit.submit('renew');
     await page.waitForURL('/', { timeout: 10_000 });
 

--- a/e2e/tests/strategy/recurring/undercut.ts
+++ b/e2e/tests/strategy/recurring/undercut.ts
@@ -5,7 +5,6 @@ import {
   assertRecurringTestCase,
   getRecurringSettings,
 } from './../../../utils/strategy';
-import { NotificationDriver } from './../../../utils/NotificationDriver';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
 import { waitModalOpen } from '../../../utils/modal';
 
@@ -62,13 +61,5 @@ export const undercutStrategyTest = (testCase: CreateStrategyTestCase) => {
       await expect(sellTooltip.maxPrice()).toHaveText(sell.max);
     }
     await sellTooltip.waitForDetached();
-
-    const notificationDriver = new NotificationDriver(page);
-    const notif = notificationDriver.getNotification('create-strategy');
-    await expect(notif.title()).toHaveText('Success');
-    await expect(notif.description()).toHaveText(
-      'New strategy was successfully created.'
-    );
-    await notificationDriver.closeAll();
   });
 };

--- a/e2e/tests/strategy/recurring/undercut.ts
+++ b/e2e/tests/strategy/recurring/undercut.ts
@@ -7,6 +7,7 @@ import {
 } from './../../../utils/strategy';
 import { ManageStrategyDriver } from './../../../utils/strategy/ManageStrategyDriver';
 import { waitModalOpen } from '../../../utils/modal';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const undercutStrategyTest = (testCase: CreateStrategyTestCase) => {
   assertRecurringTestCase(testCase);
@@ -14,7 +15,8 @@ export const undercutStrategyTest = (testCase: CreateStrategyTestCase) => {
   const { buy, sell, totalFiat } = testCase.output.undercut;
   return test('Undercut', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('duplicateStrategy');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/recurring/withdraw.ts
+++ b/e2e/tests/strategy/recurring/withdraw.ts
@@ -6,13 +6,15 @@ import {
   CreateStrategyTestCase,
   EditStrategyDriver,
 } from '../../../utils/strategy';
+import { TokenApprovalDriver } from '../../../utils/TokenApprovalDriver';
 
 export const withdrawStrategyTest = (testCase: CreateStrategyTestCase) => {
   assertRecurringTestCase(testCase);
   const { buy, sell } = testCase.output.withdraw;
   return test('Withdraw', async ({ page }) => {
     const manage = new ManageStrategyDriver(page);
-    const strategy = await manage.createStrategy(testCase);
+    const tokenApproval = new TokenApprovalDriver(page);
+    const strategy = await manage.createStrategy(testCase, { tokenApproval });
     await strategy.clickManageEntry('withdrawFunds');
 
     const modal = await waitModalOpen(page);

--- a/e2e/tests/strategy/recurring/withdraw.ts
+++ b/e2e/tests/strategy/recurring/withdraw.ts
@@ -21,6 +21,7 @@ export const withdrawStrategyTest = (testCase: CreateStrategyTestCase) => {
 
     const edit = new EditStrategyDriver(page, testCase);
     await edit.waitForPage('withdraw');
+    await edit.waitForWallet();
     await edit.fillRecurringBudget('withdraw');
 
     await edit.submit('withdraw');

--- a/e2e/utils/NotificationDriver.ts
+++ b/e2e/utils/NotificationDriver.ts
@@ -33,6 +33,7 @@ export class NotificationDriver {
   }
 
   private async closeNotif(notif: Locator) {
+    await notif.waitFor({ state: 'attached' });
     const btn = notif.getByTestId('notif-close');
     const isVisible = await btn.isVisible();
     if (isVisible) {

--- a/e2e/utils/TokenApprovalDriver.ts
+++ b/e2e/utils/TokenApprovalDriver.ts
@@ -1,0 +1,24 @@
+import { Page, expect } from '@playwright/test';
+import { waitModalOpen } from './modal';
+import { waitFor } from './operators';
+
+export class TokenApprovalDriver {
+  private approvedTokens = ['ETH'];
+  constructor(private page: Page) {}
+  async checkApproval(tokens: string[]) {
+    if (tokens.every((token) => this.approvedTokens.includes(token))) return;
+    const modal = await waitModalOpen(this.page);
+    for (const token of tokens) {
+      if (token === 'ETH') {
+        const msg = modal.getByTestId(`msg-${token}`);
+        await expect(msg).toHaveText('Pre-Approved');
+      } else {
+        await modal.getByTestId(`approve-${token}`).click();
+        const msg = await waitFor(this.page, `msg-${token}`, 20000);
+        await expect(msg).toHaveText('Approved');
+      }
+    }
+    this.approvedTokens.push(...tokens);
+    await modal.getByTestId('approve-submit').click();
+  }
+}

--- a/e2e/utils/modal.ts
+++ b/e2e/utils/modal.ts
@@ -10,8 +10,10 @@ export const closeModal = async (page: Page) => {
   return waitModalClose(page);
 };
 
+// Keep track of approved token for the current test case.
+const approvedTokens: string[] = ['ETH'];
 export const checkApproval = async (page: Page, tokens: string[]) => {
-  if (tokens.length === 1 && tokens[0] === 'ETH') return;
+  if (tokens.every((token) => approvedTokens.includes(token))) return;
   const modal = await waitModalOpen(page);
   for (const token of tokens) {
     if (token === 'ETH') {
@@ -23,6 +25,7 @@ export const checkApproval = async (page: Page, tokens: string[]) => {
       await expect(msg).toHaveText('Approved');
     }
   }
+  approvedTokens.push(...tokens);
   await modal.getByTestId('approve-submit').click();
 };
 

--- a/e2e/utils/modal.ts
+++ b/e2e/utils/modal.ts
@@ -25,3 +25,11 @@ export const checkApproval = async (page: Page, tokens: string[]) => {
   }
   await modal.getByTestId('approve-submit').click();
 };
+
+export const waitTooltipsClose = async (page: Page) => {
+  const selector = '[data-testid="tippy-tooltip"]';
+  const tooltips = await page.locator(selector).all();
+  for (const tooltip of tooltips) {
+    await tooltip.waitFor({ state: 'detached' });
+  }
+};

--- a/e2e/utils/strategy/CreateStrategyDriver.ts
+++ b/e2e/utils/strategy/CreateStrategyDriver.ts
@@ -15,7 +15,7 @@ import {
   StrategySettings,
   Setting,
 } from './types';
-import { waitModalClose, waitModalOpen } from '../modal';
+import { waitModalClose, waitModalOpen, waitTooltipsClose } from '../modal';
 import { screenshot, shouldTakeScreenshot } from '../operators';
 import { MainMenuDriver } from '../MainMenuDriver';
 
@@ -124,6 +124,8 @@ export class CreateStrategyDriver {
     if (shouldTakeScreenshot) {
       const mainMenu = new MainMenuDriver(this.page);
       await mainMenu.hide();
+      await btn.hover(); // Enforce hover to have always the same color
+      await waitTooltipsClose(this.page);
       const form = this.getForm();
       const path = screenshotPath(this.testCase, 'create', 'form');
       await screenshot(form, path);

--- a/e2e/utils/strategy/ManageStrategyDriver.ts
+++ b/e2e/utils/strategy/ManageStrategyDriver.ts
@@ -1,4 +1,7 @@
-import { DebugDriver } from './../../utils/DebugDriver';
+import {
+  CreateStrategyDependencies,
+  DebugDriver,
+} from './../../utils/DebugDriver';
 import { navigateTo } from './../../utils/operators';
 import { MyStrategyDriver } from './../../utils/strategy/MyStrategyDriver';
 import { Page } from 'playwright-core';
@@ -7,9 +10,12 @@ import { CreateStrategyTestCase } from './types';
 export class ManageStrategyDriver {
   constructor(private page: Page) {}
 
-  async createStrategy(testCase: CreateStrategyTestCase) {
+  async createStrategy(
+    testCase: CreateStrategyTestCase,
+    deps: CreateStrategyDependencies
+  ) {
     const debug = new DebugDriver(this.page);
-    await debug.createStrategy(testCase);
+    await debug.createStrategy(testCase, deps);
     await navigateTo(this.page, '/');
     const myStrategies = new MyStrategyDriver(this.page);
     return myStrategies.getStrategy(1);

--- a/e2e/utils/strategy/MyStrategyDriver.ts
+++ b/e2e/utils/strategy/MyStrategyDriver.ts
@@ -38,18 +38,25 @@ export class MyStrategyDriver {
       budgetFiat: (direction: Direction) => {
         return strategy.getByTestId(`${direction}-budget-fiat`);
       },
-      priceTooltip: async (direction: Direction) => {
+      priceTooltip: async (
+        direction: Direction,
+        options: { isOverlapping: boolean } = { isOverlapping: false }
+      ) => {
         // Note: locator.hover() doesn't work because of polygon form I think
-        const position = await strategy
-          .getByTestId(`polygon-${direction}`)
-          .boundingBox();
-        if (!position?.x || !position?.y) throw new Error('No polygon found');
-        const x =
-          direction === 'buy'
-            ? position.x + 2
-            : position.x + position.width - 2;
-        const y = position.y + 2;
-        await this.page.mouse.move(x, y);
+        if (options.isOverlapping) {
+          const position = await strategy
+            .getByTestId(`polygon-${direction}`)
+            .boundingBox();
+          if (!position?.x || !position?.y) throw new Error('No polygon found');
+          const x =
+            direction === 'buy'
+              ? position.x + 2
+              : position.x + position.width - 2;
+          const y = position.y + 2;
+          await this.page.mouse.move(x, y);
+        } else {
+          await strategy.getByTestId(`polygon-${direction}`).hover();
+        }
         const tooltip = this.page.getByTestId('order-tooltip');
         await tooltip.waitFor({ state: 'visible' });
         return {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.0.0-0",
-    "@bancor/carbon-sdk": "^0.0.94-DEV",
+    "@bancor/carbon-sdk": "0.0.94-DEV",
     "@cloudflare/workers-types": "^4.20230717.0",
     "@coinbase/wallet-sdk": "^3.6.3",
     "@ethersproject/abi": "^5.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     storageState: 'e2e/storage.json',
+    video: {
+      mode: 'retain-on-failure',
+    },
   },
 
   /* Configure projects for major browsers */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ const isCI = !!process.env.CI && process.env.CI !== 'false';
  */
 export default defineConfig({
   testDir: './e2e/pages',
-  testMatch: '**/*.spec.ts', // Realtive to testDir
+  testMatch: '**/*.spec.ts', // Relative to testDir
   outputDir: './e2e/results',
   globalSetup: './e2e/setup.ts',
   fullyParallel: true,
@@ -24,12 +24,8 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:3000',
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: isCI ? 'on-first-retry' : 'retain-on-failure',
     storageState: 'e2e/storage.json',
-    video: {
-      mode: 'retain-on-failure',
-    },
   },
 
   /* Configure projects for major browsers */

--- a/src/components/common/TokenInputField/TokenInputField.tsx
+++ b/src/components/common/TokenInputField/TokenInputField.tsx
@@ -113,32 +113,28 @@ export const TokenInputField: FC<Props> = ({
           {!slippage?.isZero() && showFiatValue && getFiatAsString(value)}
           {slippage && value && <Slippage slippage={slippage} />}
         </p>
-        {user && isBalanceLoading !== undefined && !withoutWallet && (
+        {user && !withoutWallet && isBalanceLoading && (
+          <button disabled type="button" data-testid="wallet-loading">
+            Wallet: loading
+          </button>
+        )}
+        {user && !withoutWallet && isBalanceLoading === false && (
           <button
             disabled={disabled}
             type="button"
             onClick={handleBalanceClick}
             className="group flex items-center"
           >
-            Wallet:&nbsp;
-            {isBalanceLoading ? (
-              'loading'
-            ) : (
-              <>
-                <span className="text-white">
-                  {prettifyNumber(balance || 0)}&nbsp;
-                </span>
-                <b
-                  className={
-                    disabled
-                      ? 'text-green/40'
-                      : 'text-green group-hover:text-white'
-                  }
-                >
-                  MAX
-                </b>
-              </>
-            )}
+            <span className="text-white">
+              Wallet: {prettifyNumber(balance || 0)}&nbsp;
+            </span>
+            <b
+              className={
+                disabled ? 'text-green/40' : 'text-green group-hover:text-white'
+              }
+            >
+              MAX
+            </b>
           </button>
         )}
       </div>

--- a/src/components/common/tooltip/Tooltip.tsx
+++ b/src/components/common/tooltip/Tooltip.tsx
@@ -76,6 +76,7 @@ export const Tooltip: FC<
         <m.div
           className={`rounded border border-darkGrey bg-darkGrey/30 px-24 py-16 text-14 text-white shadow-lg backdrop-blur-2xl ${className}`}
           style={{ scale, opacity, maxWidth }}
+          data-testid="tippy-tooltip"
           {...attrs}
         >
           {element}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,7 +1294,7 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@bancor/carbon-sdk@^0.0.94-DEV":
+"@bancor/carbon-sdk@0.0.94-DEV":
   version "0.0.94-DEV"
   resolved "https://registry.yarnpkg.com/@bancor/carbon-sdk/-/carbon-sdk-0.0.94-DEV.tgz#8e66182e4802b95025c43bbe9caaf57c2f66192d"
   integrity sha512-HPGdZEcv/yz/R5X2q8JeNHZ/Mw59TFuGkHNCUatvFkqoF+R1ex+eoSTsMCd+1K+JBbTlyi924B/KE9rBIOkcJA==


### PR DESCRIPTION
- Wait for wallet to be loaded
- Wait for tooltips to be closed
- Wait for notification to be attached if needed
- Remove remaining notification assertions
- Keep track on token approval
- Use textarea to create a strategy
- Use polygon.hover to open tooltips except for overlapping strategies