### PR TITLE
Quick fix: Changes to assetlist

### DIFF
--- a/src/config/sei/common.ts
+++ b/src/config/sei/common.ts
@@ -69,7 +69,7 @@ export const commonConfig: AppConfig = {
   tokenLists: [
     {
       uri: 'https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/assetlist.json',
-      parser: tokenListParser('pacific-1-evm'),
+      parser: tokenListParser('pacific-1'),
     },
   ],
 };

--- a/src/config/sei/utils.ts
+++ b/src/config/sei/utils.ts
@@ -1,3 +1,4 @@
+import { isAddress } from 'ethers/lib/utils';
 import { Token, TokenList } from 'libs/tokens';
 
 type networkDataType = {
@@ -25,7 +26,9 @@ type networkDataType = {
 export const tokenListParser =
   (networkId: string) => (data: Record<string, networkDataType[]>) => {
     const networkTokens: Token[] = data[networkId]
-      .filter((networkData) => networkData.base !== 'usei')
+      .filter((networkData) => {
+        return networkData.base !== 'usei' && isAddress(networkData.base);
+      })
       .map((networkData) => {
         return {
           name: networkData.name,


### PR DESCRIPTION
The official assetlist has had all the tokens moved from 'pacific-1-evm' to 'pacific-1', with Cosmos and non-Cosmos addresses in the same list.

- Change tag from 'pacific-1-evm' to 'pacific-1'
- Check address retrieved is EVM address