### PR TITLE
[Hotfix] Replace toSorted by sort

### DIFF
--- a/src/libs/wagmi/useWagmiNetwork.tsx
+++ b/src/libs/wagmi/useWagmiNetwork.tsx
@@ -70,7 +70,7 @@ export const useWagmiNetwork = () => {
     const connectionOrder = (selectedConnectors as string[]).map((c) =>
       c.toLowerCase()
     );
-    return unsortedConnectors.toSorted((a, b) => {
+    return [...unsortedConnectors].sort((a, b) => {
       const nameA = a.name.toLowerCase();
       const nameB = b.name.toLowerCase();
       if (!connectionOrder.includes(nameA) || !connectionOrder.includes(nameB))


### PR DESCRIPTION
Hotfix after Sentry bug report. Replace toSorted by sort which has a wider browser support