### PR TITLE
[Overlapping] Improve error message on spread

### DIFF
--- a/src/components/simulator/input/overlapping/CreateOverlappingStrategy.tsx
+++ b/src/components/simulator/input/overlapping/CreateOverlappingStrategy.tsx
@@ -24,6 +24,7 @@ import {
 import { InputRange } from 'components/strategies/create/BuySellBlock/InputRange';
 import { InputBudget } from 'components/strategies/common/InputBudget';
 import { formatNumber } from 'utils/helpers';
+import { isZero } from 'components/strategies/common/utils';
 
 interface Props {
   state: SimulatorInputOverlappingValues;
@@ -280,7 +281,7 @@ export const CreateOverlappingStrategy: FC<Props> = (props) => {
 
   // Update on buyMin changes
   useEffect(() => {
-    if (!+formatNumber(buy.min)) return;
+    if (isZero(buy.min)) return;
     const timeout = setTimeout(async () => {
       const minSellMax = getMinSellMax(Number(buy.min), spread);
       if (Number(sell.max) < minSellMax) setMax(minSellMax.toString());
@@ -291,7 +292,7 @@ export const CreateOverlappingStrategy: FC<Props> = (props) => {
 
   // Update on sellMax changes
   useEffect(() => {
-    if (!+formatNumber(sell.max)) return;
+    if (isZero(sell.max)) return;
     const timeout = setTimeout(async () => {
       const maxBuyMin = getMaxBuyMin(Number(sell.max), spread);
       if (Number(buy.min) > maxBuyMin) setMin(maxBuyMin.toString());

--- a/src/components/simulator/input/overlapping/CreateOverlappingStrategy.tsx
+++ b/src/components/simulator/input/overlapping/CreateOverlappingStrategy.tsx
@@ -341,8 +341,6 @@ export const CreateOverlappingStrategy: FC<Props> = (props) => {
         <OverlappingSpread
           buyMin={Number(buy.min)}
           sellMax={Number(sell.max)}
-          defaultValue={0.05}
-          options={[0.01, 0.05, 0.1]}
           spread={spread}
           setSpread={setSpreadValue}
         />

--- a/src/components/strategies/create/CreateOverlapping.tsx
+++ b/src/components/strategies/create/CreateOverlapping.tsx
@@ -220,8 +220,6 @@ export const CreateOverlapping: FC<Props> = (props) => {
         <OverlappingSpread
           buyMin={Number(order0.min)}
           sellMax={Number(order1.max)}
-          defaultValue={0.05}
-          options={[0.01, 0.05, 0.1]}
           spread={+spread}
           setSpread={setSpreadValue}
         />

--- a/src/components/strategies/create/CreateOverlapping.tsx
+++ b/src/components/strategies/create/CreateOverlapping.tsx
@@ -5,6 +5,7 @@ import {
   getMinSellMax,
   isMaxBelowMarket,
   isMinAboveMarket,
+  isValidSpread,
 } from 'components/strategies/overlapping/utils';
 import { Tooltip } from 'components/common/tooltip/Tooltip';
 import { OverlappingStrategyGraph } from 'components/strategies/overlapping/OverlappingStrategyGraph';
@@ -26,6 +27,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import { CreateOverlappingStrategySearch } from 'pages/strategies/create/overlapping';
 import { InputRange } from '../common/InputRange';
 import { OverlappingOrder } from 'components/strategies/common/types';
+import { isZero } from '../common/utils';
 
 interface Props {
   base: Token;
@@ -126,7 +128,7 @@ export const CreateOverlapping: FC<Props> = (props) => {
 
   // Update on buyMin changes
   useEffect(() => {
-    if (!order0.min) return;
+    if (isZero(order0.min) || !isValidSpread(spread)) return;
     const timeout = setTimeout(async () => {
       const minSellMax = getMinSellMax(Number(order0.min), Number(spread));
       if (Number(order1.max) < minSellMax) set('max', minSellMax.toString());
@@ -137,7 +139,7 @@ export const CreateOverlapping: FC<Props> = (props) => {
 
   // Update on sellMax changes
   useEffect(() => {
-    if (!order1.max) return;
+    if (isZero(order1.max) || !isValidSpread(spread)) return;
     const timeout = setTimeout(async () => {
       const maxBuyMin = getMaxBuyMin(Number(order1.max), Number(spread));
       if (Number(order0.min) > maxBuyMin) set('min', maxBuyMin.toString());

--- a/src/components/strategies/edit/EditOverlappingPrice.tsx
+++ b/src/components/strategies/edit/EditOverlappingPrice.tsx
@@ -287,8 +287,6 @@ export const EditOverlappingPrice: FC<Props> = (props) => {
         <OverlappingSpread
           buyMin={Number(order0.min)}
           sellMax={Number(order1.max)}
-          defaultValue={0.05}
-          options={[0.01, 0.05, 0.1]}
           spread={+spread}
           setSpread={setSpread}
         />

--- a/src/components/strategies/edit/EditOverlappingPrice.tsx
+++ b/src/components/strategies/edit/EditOverlappingPrice.tsx
@@ -6,6 +6,7 @@ import {
   hasArbOpportunity,
   isMaxBelowMarket,
   isMinAboveMarket,
+  isValidSpread,
 } from 'components/strategies/overlapping/utils';
 import { Tooltip } from 'components/common/tooltip/Tooltip';
 import { OverlappingStrategyGraph } from 'components/strategies/overlapping/OverlappingStrategyGraph';
@@ -29,6 +30,7 @@ import { useEditStrategyCtx } from './EditStrategyContext';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { EditOverlappingStrategySearch } from 'pages/strategies/edit/prices/overlapping';
 import { InputRange } from '../common/InputRange';
+import { isZero } from '../common/utils';
 
 interface Props {
   marketPrice: string;
@@ -201,7 +203,7 @@ export const EditOverlappingPrice: FC<Props> = (props) => {
 
   // Update on buyMin changes
   useEffect(() => {
-    if (!order0.min) return;
+    if (isZero(order0.min) || !isValidSpread(spread)) return;
     const timeout = setTimeout(async () => {
       const minSellMax = getMinSellMax(Number(order0.min), Number(spread));
       if (Number(order1.max) < minSellMax) set('max', minSellMax.toString());
@@ -212,7 +214,7 @@ export const EditOverlappingPrice: FC<Props> = (props) => {
 
   // Update on sellMax changes
   useEffect(() => {
-    if (!order1.max) return;
+    if (isZero(order1.max) || !isValidSpread(spread)) return;
     const timeout = setTimeout(async () => {
       const maxBuyMin = getMaxBuyMin(Number(order1.max), Number(spread));
       if (Number(order0.min) > maxBuyMin) set('min', maxBuyMin.toString());

--- a/src/components/strategies/overlapping/OverlappingSpread.tsx
+++ b/src/components/strategies/overlapping/OverlappingSpread.tsx
@@ -20,6 +20,7 @@ export const OverlappingSpread: FC<Props> = (props) => {
   const root = useRef<HTMLDivElement>(null);
   const inOptions = options.includes(spread);
   const maxSpread = round(getMaxSpread(buyMin, sellMax));
+  const isValidMaxSpread = maxSpread > 0 && maxSpread < 100;
   const hasError = spread <= 0 || spread > maxSpread || spread > 100;
 
   const onKeyDown = (e: KeyboardEvent) => {
@@ -123,7 +124,7 @@ export const OverlappingSpread: FC<Props> = (props) => {
           <span className={styles.suffix}>%</span>
         </div>
       </div>
-      {spread > maxSpread && (
+      {isValidMaxSpread && spread > maxSpread && (
         <Warning htmlFor="spread-custom" isError>
           Given price range, max fee tier cannot exceed&nbsp;
           <button onClick={setMax} className="font-weight-600 border-b">
@@ -131,14 +132,9 @@ export const OverlappingSpread: FC<Props> = (props) => {
           </button>
         </Warning>
       )}
-      {spread <= 0 && (
+      {isValidMaxSpread && spread <= 0 && (
         <Warning htmlFor="spread-custom" isError>
           The fee tier should be above 0%
-        </Warning>
-      )}
-      {maxSpread > 100 && spread > 100 && (
-        <Warning htmlFor="spread-custom" isError>
-          The fee tier should be equal or below 100%
         </Warning>
       )}
     </>

--- a/src/components/strategies/overlapping/OverlappingSpread.tsx
+++ b/src/components/strategies/overlapping/OverlappingSpread.tsx
@@ -1,53 +1,26 @@
-import {
-  useRef,
-  FC,
-  KeyboardEvent,
-  useState,
-  FocusEvent,
-  ChangeEvent,
-} from 'react';
-import { cn, formatNumber, sanitizeNumber } from 'utils/helpers';
+import { useRef, FC, KeyboardEvent, FocusEvent, ChangeEvent } from 'react';
+import { cn, formatNumber } from 'utils/helpers';
 import { getMaxSpread } from 'components/strategies/overlapping/utils';
 import { Warning } from 'components/common/WarningMessageWithIcon';
 import styles from './OverlappingSpread.module.css';
 
 interface Props {
-  /** Value used to fallback to when custom input is empty */
-  defaultValue: number;
-  options: number[];
   spread: number;
   buyMin: number;
   sellMax: number;
   setSpread: (value: number) => void;
 }
 
-const getWarning = (maxSpread: number) => {
-  return `Given price range, max fee tier cannot exceed ${maxSpread}%`;
-};
-
+export const defaultSpread = '0.05';
+const options = [0.01, 0.05, 0.1];
 const round = (value: number) => Math.round(value * 100) / 100;
 
 export const OverlappingSpread: FC<Props> = (props) => {
-  const { defaultValue, options, spread, setSpread, buyMin, sellMax } = props;
+  const { spread, setSpread, buyMin, sellMax } = props;
   const root = useRef<HTMLDivElement>(null);
   const inOptions = options.includes(spread);
-  const hasError = spread <= 0 || spread > 100;
-  const [warning, setWarning] = useState('');
-
-  const selectSpread = (value: number) => {
-    const input = document.getElementById('spread-custom') as HTMLInputElement;
-    const maxSpread = round(getMaxSpread(buyMin, sellMax));
-    if (value > maxSpread) {
-      setWarning(getWarning(maxSpread));
-      setSpread(maxSpread);
-      input.value = maxSpread.toFixed(2);
-      input.focus();
-    } else {
-      setWarning('');
-      setSpread(value);
-      input.value = '';
-    }
-  };
+  const maxSpread = round(getMaxSpread(buyMin, sellMax));
+  const hasError = spread <= 0 || spread > maxSpread || spread > 100;
 
   const onKeyDown = (e: KeyboardEvent) => {
     const fieldset = root.current!;
@@ -66,33 +39,30 @@ export const OverlappingSpread: FC<Props> = (props) => {
     }
   };
 
+  const selectSpread = (value: number) => {
+    const input = document.getElementById('spread-custom') as HTMLInputElement;
+    setSpread(value);
+    input.value = '';
+  };
+
+  const setMax = () => {
+    const input = document.getElementById('spread-custom') as HTMLInputElement;
+    setSpread(maxSpread);
+    input.value = formatNumber(maxSpread.toFixed(6));
+  };
+
   const onCustomChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.value) return;
-    const value = Number(e.target.value);
-    const maxSpread = round(getMaxSpread(buyMin, sellMax));
-    if (isNaN(value)) {
-      e.target.value = sanitizeNumber(e.target.value);
-    } else if (value > maxSpread) {
-      setWarning(getWarning(maxSpread));
-      setSpread(maxSpread);
-      e.target.value = maxSpread.toFixed(2);
-    } else {
-      setWarning('');
-      setSpread(value);
-    }
+    setSpread(Number(e.target.value));
   };
 
   const onCustomBlur = (e: FocusEvent<HTMLInputElement>) => {
-    if (options.includes(e.target.valueAsNumber)) {
+    if (options.includes(spread)) {
       e.target.value = '';
     } else {
       const value = formatNumber(e.target.value);
-      if (!value || !Number(value)) {
-        setSpread(defaultValue);
-        e.target.value = '';
-      } else {
-        e.target.value = Number(value).toFixed(2);
-      }
+      const trimmed = Number(value).toFixed(2);
+      if (options.includes(+trimmed)) selectSpread(+trimmed);
+      else e.target.value = trimmed;
     }
   };
 
@@ -153,15 +123,20 @@ export const OverlappingSpread: FC<Props> = (props) => {
           <span className={styles.suffix}>%</span>
         </div>
       </div>
-      {warning && spread && (
-        <Warning htmlFor="spread-custom">{warning}</Warning>
+      {spread > maxSpread && (
+        <Warning htmlFor="spread-custom" isError>
+          Given price range, max fee tier cannot exceed&nbsp;
+          <button onClick={setMax} className="font-weight-600 border-b">
+            {maxSpread}%
+          </button>
+        </Warning>
       )}
       {spread <= 0 && (
         <Warning htmlFor="spread-custom" isError>
           The fee tier should be above 0%
         </Warning>
       )}
-      {spread > 100 && (
+      {maxSpread > 100 && spread > 100 && (
         <Warning htmlFor="spread-custom" isError>
           The fee tier should be equal or below 100%
         </Warning>

--- a/src/components/strategies/overlapping/OverlappingStrategyGraph.tsx
+++ b/src/components/strategies/overlapping/OverlappingStrategyGraph.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as IconCoinGecko } from 'assets/icons/coin-gecko.svg';
 import { getSignedMarketPricePercentage } from 'components/strategies/marketPriceIndication/utils';
 import { SafeDecimal } from 'libs/safedecimal';
 import { Token } from 'libs/tokens';
-import { getMaxBuyMin, getMinSellMax } from './utils';
+import { getMaxBuyMin, getMaxSpread, getMinSellMax } from './utils';
 import { calculateOverlappingPrices } from '@bancor/carbon-sdk/strategy-management';
 import { marketPricePercent } from '../marketPriceIndication/useMarketIndication';
 import { useMarketPrice } from 'hooks/useMarketPrice';
@@ -161,7 +161,8 @@ export const OverlappingStrategyGraph: FC<Props> = (props) => {
   const svg = useRef<SVGSVGElement>(null);
   const [zoom, setZoom] = useState(0.4);
   const [dragging, setDragging] = useState('');
-  const { base, quote, order0, order1, spread } = props;
+  const { base, quote, order0, order1 } = props;
+  const spread = clamp(0, props.spread, getMaxSpread(+order0.min, +order1.max));
   const baseMin = Number(formatNumber(order0.min));
   const baseMax = Number(formatNumber(order1.max));
   const disabled = !!props.disabled;

--- a/src/pages/strategies/create/overlapping.tsx
+++ b/src/pages/strategies/create/overlapping.tsx
@@ -24,6 +24,7 @@ import {
   CreateForm,
   CreateFormHeader,
 } from 'components/strategies/create/CreateForm';
+import { defaultSpread } from 'components/strategies/overlapping/OverlappingSpread';
 
 export interface CreateOverlappingStrategySearch {
   base: string;
@@ -36,8 +37,6 @@ export interface CreateOverlappingStrategySearch {
   budget?: string;
 }
 type Search = CreateOverlappingStrategySearch;
-
-const initSpread = '0.05';
 
 const initMin = (marketPrice: string) => {
   return new SafeDecimal(marketPrice).times(0.99).toString();
@@ -63,7 +62,7 @@ const getOrders = (
     anchor,
     min = initMin(marketPrice),
     max = initMax(marketPrice),
-    spread = initSpread,
+    spread = defaultSpread.toString(),
     budget,
   } = search;
   if (!isValidRange(min, max) || !isValidSpread(spread)) {
@@ -177,7 +176,7 @@ export const CreateOverlappingStrategyPage = () => {
           marketPrice={marketPrice}
           order0={orders.buy}
           order1={orders.sell}
-          spread={search.spread || initSpread}
+          spread={search.spread || defaultSpread.toString()}
         />
       </CreateForm>
     </CreateLayout>

--- a/src/pages/strategies/edit/prices/overlapping.tsx
+++ b/src/pages/strategies/edit/prices/overlapping.tsx
@@ -25,6 +25,7 @@ import { isZero } from 'components/strategies/common/utils';
 import { getTotalBudget } from 'components/strategies/edit/utils';
 import { CarbonLogoLoading } from 'components/common/CarbonLogoLoading';
 import { EditStrategyForm } from 'components/strategies/edit/EditStrategyForm';
+import { defaultSpread } from 'components/strategies/overlapping/OverlappingSpread';
 
 export interface EditOverlappingStrategySearch {
   editType: 'editPrices' | 'renew';
@@ -36,8 +37,6 @@ export interface EditOverlappingStrategySearch {
   budget?: string;
   action?: 'deposit' | 'withdraw';
 }
-
-const initSpread = '0.05';
 
 const initMin = (marketPrice: string) => {
   return new SafeDecimal(marketPrice).times(0.99).toString();
@@ -78,7 +77,7 @@ const getOrders = (
     anchor,
     min = initMin(userMarketPrice),
     max = initMax(userMarketPrice),
-    spread = initSpread,
+    spread = defaultSpread,
     budget = '0',
     action = 'deposit',
   } = search;
@@ -167,7 +166,7 @@ export const EditStrategyOverlappingPage = () => {
   const marketPrice = search.marketPrice ?? externalPrice?.toString();
 
   const orders = getOrders(strategy, search, marketPrice);
-  const spread = isValidSpread(search.spread) ? search.spread! : initSpread;
+  const spread = search.spread || defaultSpread;
 
   const hasChanged = (() => {
     const { order0, order1 } = strategy;


### PR DESCRIPTION
- Display the max spread in the error
- Do not calculate min/max when spread is invalid
- Do not display a warning when max spread is invalid (when min > max)

![image](https://github.com/bancorprotocol/carbon-app/assets/8143464/01023123-8c7c-4201-8455-b013fef7e51e)
