### PR TITLE
Update default trading pair from SEI-WSEI to SEI-USDC

### DIFF
--- a/src/config/sei/common.ts
+++ b/src/config/sei/common.ts
@@ -39,7 +39,7 @@ export const commonConfig: AppConfig = {
       logoURI: 'https://cdn.sei.io/assets/Sei_Symbol_Gradient.svg',
     },
   },
-  defaultTokenPair: [addresses.SEI, addresses.WSEI],
+  defaultTokenPair: [addresses.SEI, addresses.USDC],
   popularPairs: [
     [addresses.SEI, addresses.WSEI],
     [addresses.SEI, addresses.USDC],


### PR DESCRIPTION
fix #1263 

On the Sei app, this are the current observed behaviours:
1. Go to explore
2. Explore redirects to SEI-WSEI pair

1. Go to trade page (first time visit or cleared cache)
2. Trade page redirect to SEI-WSEI pair

This PR changes the behaviours above to:
1. Go to explore
2. Explore redirects to SEI-USDC

1. Go to trade page (first time visit or cleared cache)
2. Trade page redirect to SEI-USDC pair