### PR TITLE
Issue #1308 - Remove analytics link for Sei

### DIFF
--- a/src/components/core/menu/mainMenu/MainMenuRightBurger/MenuItem.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightBurger/MenuItem.tsx
@@ -5,7 +5,7 @@ import { cn } from 'utils/helpers';
 type MenuItemProps = {
   item: {
     onClick?: Function;
-    content: string | ReactElement;
+    content?: string | ReactElement;
     hasSubMenu?: boolean;
     disableHoverEffect?: boolean;
     className?: string;

--- a/src/components/core/menu/mainMenu/MainMenuRightBurger/index.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightBurger/index.tsx
@@ -15,7 +15,9 @@ export const MainMenuRightBurger: FC<{
     menuMapping,
   });
 
-  const currentMenuItems = menuContext.top()?.items;
+  const currentMenuItems = menuContext
+    .top()
+    ?.items.filter((item) => !!item.content);
 
   return (
     <DropdownMenu

--- a/src/components/core/menu/mainMenu/MainMenuRightBurger/useBurgerMenuItems.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightBurger/useBurgerMenuItems.tsx
@@ -10,7 +10,7 @@ import { ReactComponent as IconV } from 'assets/icons/v.svg';
 
 export type MenuItemType = {
   subMenu?: MenuType;
-  content: string | ReactElement;
+  content?: string | ReactElement;
   onClick?: Function;
   postClickAction?: MenuItemActions;
 };
@@ -42,17 +42,13 @@ export const useBurgerMenuItems = () => {
         </NewTabLink>
       ),
     },
-    ...(externalLinks.analytics
-      ? [
-          {
-            content: (
-              <NewTabLink className="flex" to={externalLinks.analytics}>
-                Analytics
-              </NewTabLink>
-            ),
-          },
-        ]
-      : []),
+    {
+      content: externalLinks.analytics && (
+        <NewTabLink className="flex" to={externalLinks.analytics}>
+          Analytics
+        </NewTabLink>
+      ),
+    },
     {
       content: (
         <NewTabLink className="flex" to={externalLinks.blog}>
@@ -160,39 +156,27 @@ export const useBurgerMenuItems = () => {
         </NewTabLink>
       ),
     },
-    ...(externalLinks.simulatorRepo
-      ? [
-          {
-            content: (
-              <NewTabLink className="flex" to={externalLinks.simulatorRepo}>
-                Simulator Repo
-              </NewTabLink>
-            ),
-          },
-        ]
-      : []),
-    ...(externalLinks.interactiveSim
-      ? [
-          {
-            content: (
-              <NewTabLink className="flex" to={externalLinks.interactiveSim}>
-                Interactive Simulator
-              </NewTabLink>
-            ),
-          },
-        ]
-      : []),
-    ...(externalLinks.duneDashboard
-      ? [
-          {
-            content: (
-              <NewTabLink className="flex" to={externalLinks.duneDashboard}>
-                Dune Dashboard
-              </NewTabLink>
-            ),
-          },
-        ]
-      : []),
+    {
+      content: externalLinks.simulatorRepo && (
+        <NewTabLink className="flex" to={externalLinks.simulatorRepo}>
+          Simulator Repo
+        </NewTabLink>
+      ),
+    },
+    {
+      content: externalLinks.interactiveSim && (
+        <NewTabLink className="flex" to={externalLinks.interactiveSim}>
+          Interactive Simulator
+        </NewTabLink>
+      ),
+    },
+    {
+      content: externalLinks.duneDashboard && (
+        <NewTabLink className="flex" to={externalLinks.duneDashboard}>
+          Dune Dashboard
+        </NewTabLink>
+      ),
+    },
   ];
 
   menuMap.set('main', { items: mainItems });

--- a/src/components/core/menu/mainMenu/MainMenuRightBurger/useBurgerMenuItems.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightBurger/useBurgerMenuItems.tsx
@@ -42,13 +42,17 @@ export const useBurgerMenuItems = () => {
         </NewTabLink>
       ),
     },
-    {
-      content: (
-        <NewTabLink className="flex" to={externalLinks.analytics}>
-          Analytics
-        </NewTabLink>
-      ),
-    },
+    ...(externalLinks.analytics
+      ? [
+          {
+            content: (
+              <NewTabLink className="flex" to={externalLinks.analytics}>
+                Analytics
+              </NewTabLink>
+            ),
+          },
+        ]
+      : []),
     {
       content: (
         <NewTabLink className="flex" to={externalLinks.blog}>

--- a/src/components/core/menu/mainMenu/MainMenuRightBurger/useBurgerMenuItems.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightBurger/useBurgerMenuItems.tsx
@@ -160,27 +160,39 @@ export const useBurgerMenuItems = () => {
         </NewTabLink>
       ),
     },
-    {
-      content: (
-        <NewTabLink className="flex" to={externalLinks.simulatorRepo}>
-          Simulator Repo
-        </NewTabLink>
-      ),
-    },
-    {
-      content: (
-        <NewTabLink className="flex" to={externalLinks.interactiveSim}>
-          Interactive Simulator
-        </NewTabLink>
-      ),
-    },
-    {
-      content: (
-        <NewTabLink className="flex" to={externalLinks.duneDashboard}>
-          Dune Dashboard
-        </NewTabLink>
-      ),
-    },
+    ...(externalLinks.simulatorRepo
+      ? [
+          {
+            content: (
+              <NewTabLink className="flex" to={externalLinks.simulatorRepo}>
+                Simulator Repo
+              </NewTabLink>
+            ),
+          },
+        ]
+      : []),
+    ...(externalLinks.interactiveSim
+      ? [
+          {
+            content: (
+              <NewTabLink className="flex" to={externalLinks.interactiveSim}>
+                Interactive Simulator
+              </NewTabLink>
+            ),
+          },
+        ]
+      : []),
+    ...(externalLinks.duneDashboard
+      ? [
+          {
+            content: (
+              <NewTabLink className="flex" to={externalLinks.duneDashboard}>
+                Dune Dashboard
+              </NewTabLink>
+            ),
+          },
+        ]
+      : []),
   ];
 
   menuMap.set('main', { items: mainItems });

--- a/src/config/ethereum/common.ts
+++ b/src/config/ethereum/common.ts
@@ -27,7 +27,12 @@ export const commonConfig: AppConfig = {
   appName: 'Carbon DeFi',
   appUrl: 'https://app.carbondefi.xyz',
   carbonApi: 'https://api.carbondefi.xyz/v1/',
-  carbonAnalytics: 'http://analytics.carbondefi.xyz',
+  externalLinks: {
+    analytics: 'http://analytics.carbondefi.xyz',
+    interactiveSim: 'https://simulator.carbondefi.xyz/',
+    simulatorRepo: 'https://github.com/bancorprotocol/carbon-simulator',
+    duneDashboard: 'https://dune.com/bancor/carbon-by-bancor',
+  },
   selectedConnectors: ['MetaMask', 'WalletConnect', 'Coinbase Wallet', 'Safe'],
   blockedConnectors: ['Tailwind', 'Compass Wallet', 'Seif'],
   walletConnectProjectId: 'f9d8863ab6c03f2293d7d56d7c0c0853',

--- a/src/config/ethereum/common.ts
+++ b/src/config/ethereum/common.ts
@@ -27,6 +27,7 @@ export const commonConfig: AppConfig = {
   appName: 'Carbon DeFi',
   appUrl: 'https://app.carbondefi.xyz',
   carbonApi: 'https://api.carbondefi.xyz/v1/',
+  carbonAnalytics: 'http://analytics.carbondefi.xyz',
   selectedConnectors: ['MetaMask', 'WalletConnect', 'Coinbase Wallet', 'Safe'],
   blockedConnectors: ['Tailwind', 'Compass Wallet', 'Seif'],
   walletConnectProjectId: 'f9d8863ab6c03f2293d7d56d7c0c0853',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,7 +10,7 @@ export interface AppConfig {
   appName: string;
   appUrl: string;
   carbonApi: string;
-  carbonAnalytics?: string;
+  externalLinks?: Record<string, string>;
   selectedConnectors: SelectableConnectionName[];
   blockedConnectors?: SelectableConnectionName[];
   walletConnectProjectId: string;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,6 +10,7 @@ export interface AppConfig {
   appName: string;
   appUrl: string;
   carbonApi: string;
+  carbonAnalytics?: string;
   selectedConnectors: SelectableConnectionName[];
   blockedConnectors?: SelectableConnectionName[];
   walletConnectProjectId: string;

--- a/src/libs/modals/modals/ModalBurgerMenu.tsx
+++ b/src/libs/modals/modals/ModalBurgerMenu.tsx
@@ -19,7 +19,9 @@ export const ModalBurgerMenu: ModalFC<undefined> = ({ id }) => {
     defaultState: true,
   });
 
-  const currentMenuItems = menuContext.top()?.items;
+  const currentMenuItems = menuContext
+    .top()
+    ?.items.filter((item) => !!item.content);
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/libs/routing/externalLinks.ts
+++ b/src/libs/routing/externalLinks.ts
@@ -3,7 +3,7 @@ export const externalLinks = {
   carbonHomepage: 'https://carbondefi.xyz',
   blog: 'https://blog.carbondefi.xyz',
   faq: 'https://faq.carbondefi.xyz/',
-  analytics: 'http://analytics.carbondefi.xyz',
+  analytics: config.carbonAnalytics,
   x: 'https://x.com/carbondefixyz',
   youtube: 'https://www.youtube.com/c/BancorProtocol',
   discord: 'https://discord.gg/bancor',

--- a/src/libs/routing/externalLinks.ts
+++ b/src/libs/routing/externalLinks.ts
@@ -1,9 +1,14 @@
 import config from 'config';
 export const externalLinks = {
+  analytics: config.externalLinks?.analytics,
+  simulatorRepo: config.externalLinks?.simulatorRepo,
+  interactiveSim: config.externalLinks?.interactiveSim,
+  duneDashboard: config.externalLinks?.duneDashboard,
+  terms: config.appUrl + '/terms',
+  privacy: config.appUrl + '/privacy',
   carbonHomepage: 'https://carbondefi.xyz',
   blog: 'https://blog.carbondefi.xyz',
   faq: 'https://faq.carbondefi.xyz/',
-  analytics: config.carbonAnalytics,
   x: 'https://x.com/carbondefixyz',
   youtube: 'https://www.youtube.com/c/BancorProtocol',
   discord: 'https://discord.gg/bancor',
@@ -11,14 +16,9 @@ export const externalLinks = {
   techDocs: 'https://docs.carbondefi.xyz/',
   litePaper: 'https://carbondefi.xyz/litepaper',
   whitepaper: 'https://carbondefi.xyz/whitepaper',
-  simulatorRepo: 'https://github.com/bancorprotocol/carbon-simulator',
-  interactiveSim: 'https://simulator.carbondefi.xyz/',
-  duneDashboard: 'https://dune.com/bancor/carbon-by-bancor',
   roiLearnMore: 'https://faq.carbondefi.xyz/strategy-roi-and-apr',
   treasuryGov:
     'https://home.treasury.gov/policy-issues/financial-sanctions/recent-actions/20220808',
-  terms: config.appUrl + '/terms',
-  privacy: config.appUrl + '/privacy',
   whatIsOverlapping:
     'https://faq.carbondefi.xyz/what-is-an-overlapping-strategy#overlapping-budget-dynamics',
 };


### PR DESCRIPTION
- Add optional carbonAnalytics config param and add it to the Ethereum config only
- Remove "Analytics" from menu if url is undefined in config
- Remove "Dune Dashboard" from menu if url is undefined in config
- Remove "Interactive Sim" from menu if url is undefined in config
- Remove "Simulator Repo" from menu if url is undefined in config

fix #1308