### PR TITLE
revert the changes made in PR 1335 - led to loading CTA

### DIFF
--- a/src/components/strategies/create/CreateForm.tsx
+++ b/src/components/strategies/create/CreateForm.tsx
@@ -72,8 +72,13 @@ export const CreateForm: FC<FormProps> = (props) => {
   const { user } = useWagmi();
   const search = useSearch({ strict: false }) as any;
 
-  const { isLoading, isProcessing, isAwaiting, createStrategy } =
-    useCreateStrategy({ type, base, quote, order0, order1 });
+  const { isProcessing, isAwaiting, createStrategy } = useCreateStrategy({
+    type,
+    base,
+    quote,
+    order0,
+    order1,
+  });
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -82,7 +87,7 @@ export const CreateForm: FC<FormProps> = (props) => {
     return () => clearTimeout(timeout);
   }, [type, search]);
 
-  const loading = isLoading || isProcessing || isAwaiting;
+  const loading = isProcessing || isAwaiting;
   const loadingChildren = getStatusTextByTxStatus(isAwaiting, isProcessing);
 
   const connectWallet = () => {

--- a/src/components/strategies/create/useCreateStrategy.ts
+++ b/src/components/strategies/create/useCreateStrategy.ts
@@ -159,7 +159,6 @@ export const useCreateStrategy = (props: Props) => {
   };
 
   return {
-    isLoading: approval.isPending,
     isAwaiting: mutation.isPending,
     createStrategy,
     isProcessing,

--- a/src/components/strategies/edit/EditStrategyForm.tsx
+++ b/src/components/strategies/edit/EditStrategyForm.tsx
@@ -106,8 +106,7 @@ export const EditStrategyForm: FC<Props> = (props) => {
     return arr;
   })();
   const approval = useApproval(approvalTokens);
-  const isLoading =
-    approval.isPending || isPending || isProcessing || isDeleting;
+  const isLoading = isPending || isProcessing || isDeleting;
   const loadingChildren = getStatusTextByTxStatus(
     isPending,
     isProcessing || isDeleting


### PR DESCRIPTION
When creating or editing a strategy, if the wallet is not connected, the "Connect Wallet" CTA will stay in a loading state.
