### PR TITLE
Fix init-sentry to only send console errors to Sentry

### DIFF
--- a/src/init-sentry.ts
+++ b/src/init-sentry.ts
@@ -8,7 +8,7 @@ if (config.sentryDSN) {
     integrations: [
       Sentry.tanstackRouterBrowserTracingIntegration(router),
       Sentry.replayIntegration(),
-      Sentry.captureConsoleIntegration(),
+      Sentry.captureConsoleIntegration({ levels: ['error'] }),
     ],
     // Performance Monitoring
     tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!


### PR DESCRIPTION
Sentry.captureConsoleIntegration() has the following options for what console output to send to Sentry:

['log', 'info', 'warn', 'error', 'debug', 'assert']

This PR changes the init-sentry to only send console output for 'error'