### PR TITLE
POC: Implement single page network switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ The app will use the rpc for the following purposes:
 
 If VITE_CHAIN_RPC_URL is not set, the app will use the rpc.url and rpc.headers from the development/production network configuration.
 
+### Network switch
+
+The network switch is available in the header of the app. It allows the user to switch between networks and has the following behavior:
+
+- If running with VITE_USE_STORED_CHAIN_SWITCH flag set to true, it will change the network in the same page storing the selected network in the local storage.
+- If running with VITE_USE_STORED_CHAIN_SWITCH flag set to false, it will redirect the user to the home page of the selected network set in config `appUrl`.
+
+If changing the network in the same page, it is recommended to set the chain rpc url via the config instead of using VITE_CHAIN_RPC_URL
+
 ### Contracts with version < 5
 
 In case the network is using a version of CarbonController older than 5 then there's no support for extended range for trade by source,

--- a/src/components/core/menu/mainMenu/MainMenuRightChainSelector.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightChainSelector.tsx
@@ -10,8 +10,8 @@ interface Props {
     id: string;
     name: string;
     logoUrl: string;
-    appUrl: string;
     isCurrentNetwork: boolean;
+    selectNetwork: () => void;
   }[];
 }
 
@@ -44,27 +44,24 @@ export const MainMenuRightChainSelector: FC<Props> = ({ networks }) => {
       )}
     >
       {networks.map((network) => {
-        const { id, name, logoUrl, appUrl, isCurrentNetwork } = network;
+        const { id, name, logoUrl, selectNetwork, isCurrentNetwork } = network;
         return (
-          <a
+          <button
             key={id}
             role="menuitem"
             className={cn(
               'rounded-6 flex w-full items-center gap-x-10 p-12',
-              isCurrentNetwork
-                ? 'pointer-events-none bg-black'
-                : 'hover:bg-black'
+              isCurrentNetwork ? 'bg-black' : 'hover:bg-black'
             )}
-            href={appUrl}
-            aria-current={isCurrentNetwork}
-            aria-disabled={isCurrentNetwork}
+            onClick={() => selectNetwork()}
+            disabled={isCurrentNetwork}
           >
             <img alt={name} src={logoUrl} className="w-20" />
             <span>{name}</span>
             <IconCheck
               className={cn('ml-auto', isCurrentNetwork ? '' : 'invisible')}
             />
-          </a>
+          </button>
         );
       })}
     </DropdownMenu>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,8 +23,14 @@ const configs = {
 type Network = keyof typeof configs;
 type Mode = 'development' | 'production';
 
-const network = (import.meta.env.VITE_NETWORK || 'ethereum') as Network;
 const mode = import.meta.env.MODE as Mode;
+const useStoredChainSwitch = !!import.meta.env.VITE_USE_STORED_CHAIN_SWITCH;
+
+export const network = ((useStoredChainSwitch
+  ? localStorage.getItem('currentNetwork')
+  : undefined) ||
+  import.meta.env.VITE_NETWORK ||
+  'ethereum') as Network;
 
 if (!configs[network]) {
   const networks = Object.keys(configs).join(' or ');
@@ -41,7 +47,14 @@ export const networks = Object.entries(configs).map(([id, config]) => {
     name: config[mode].network.name,
     logoUrl: config[mode].network.logoUrl,
     isCurrentNetwork: network === id,
-    appUrl: config[mode].appUrl,
+    selectNetwork: () => {
+      if (useStoredChainSwitch) {
+        localStorage.setItem('currentNetwork', id);
+        window.location.reload();
+      } else {
+        window.location.href = config[mode].appUrl;
+      }
+    },
   };
 });
 

--- a/src/services/localeStorage/index.ts
+++ b/src/services/localeStorage/index.ts
@@ -10,14 +10,11 @@ import {
   StrategyFilter,
   StrategySort,
 } from 'components/strategies/overview/StrategyFilterSort';
-import { APP_ID, APP_VERSION, NETWORK } from 'utils/constants';
+import { APP_ID, APP_VERSION } from 'utils/constants';
 import { FiatSymbol } from 'utils/carbonApi';
-import {
-  Migration,
-  migrateAndRemoveItem,
-  removeItem,
-} from 'utils/migrateLocalStorage';
+import { Migration, removeItem } from 'utils/migrateLocalStorage';
 import { NotificationPreference } from 'libs/notifications/NotificationPreferences';
+import { network } from 'config';
 
 // ************************** /
 // BEWARE!! Keys are not to be removed or changed without setting a proper clean-up and migration logic in place!! Same for changing the app version!
@@ -77,15 +74,12 @@ const migrations: Migration[] = [
       const prefix = 'carbon-v1.1-';
       const isMatch = prevFormattedKey.startsWith(prefix);
       if (!isMatch) return;
-      const key = prevFormattedKey.slice(prefix.length);
-      if (!key) return;
-      const nextFormattedKey = ['carbon', NETWORK, 'v1.1', key].join('-');
-      migrateAndRemoveItem({ prevFormattedKey, nextFormattedKey });
+      removeItem({ prevFormattedKey });
     },
   },
 ];
 
 export const lsService = new ManagedLocalStorage<LocalStorageSchema>(
-  (key) => [APP_ID, NETWORK, APP_VERSION, key].join('-'),
+  (key) => [APP_ID, network, APP_VERSION, key].join('-'),
   migrations
 );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,2 @@
 export const APP_ID = 'carbon';
 export const APP_VERSION = 'v1.1';
-export const NETWORK = import.meta.env.VITE_NETWORK || 'ethereum';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_TENDERLY_ACCESS_KEY: string;
   readonly VITE_SDK_VERBOSITY: 0 | 1 | 2;
   readonly VITE_LEGACY_TRADE_BY_SOURCE_RANGE: boolean;
+  readonly VITE_USE_STORED_CHAIN_SWITCH: boolean;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This PR is a POC on how to implement single page network switching via setting the currentNetwork in localStorage and using it if the env variable VITE_USE_STORED_CHAIN_SWITCH is set to true. If this env variable is undefined or set to false, the switch network behaviour will remain the same - directing to the appUrl.

- Add env variable to choose which way to change network is preferred
- Add currentNetwork to localStorage to store current chain
- Change switch chain button to change current chain in app local storage
- Update readme.md with instructions on how to set the single page network switch
- Remove all carbon-v1.1 keys to make sure they don't clash with the currently selected network for single applications