### PR TITLE
fix filter & empty state

### DIFF
--- a/e2e/utils/modal.ts
+++ b/e2e/utils/modal.ts
@@ -32,6 +32,7 @@ export const checkApproval = async (page: Page, tokens: string[]) => {
 
 export const waitTooltipsClose = async (page: Page) => {
   const selector = '[data-testid="tippy-tooltip"]';
+  await page.mouse.move(0, 0);
   const tooltips = await page.locator(selector).all();
   for (const tooltip of tooltips) {
     await tooltip.waitFor({ state: 'detached' });

--- a/src/components/activity/ActivityProvider.tsx
+++ b/src/components/activity/ActivityProvider.tsx
@@ -7,8 +7,6 @@ import { ActivitySearchParams } from './utils';
 import { FC, ReactNode, createContext, useCallback, useContext } from 'react';
 import { useActivityQuery, useActivityMetaQuery } from './useActivityQuery';
 import { CarbonLogoLoading } from 'components/common/CarbonLogoLoading';
-import { NotFound } from 'components/common/NotFound';
-import { useGetUserStrategies } from 'libs/queries';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { isEmpty } from 'utils/helpers/operators';
 import { addDays, getUnixTime } from 'date-fns';
@@ -39,10 +37,7 @@ const getQueryParams = (
   const params = { ...baseParams };
   if (searchParams.actions) params.actions = searchParams.actions.join(',');
   if (searchParams.ids) params.strategyIds = searchParams.ids?.join(',');
-  if (searchParams.pairs)
-    params.pairs = searchParams.pairs
-      .map((pair) => `${pair[0]}_${pair[1]}`)
-      .join(',');
+  if (searchParams.pairs) params.pairs = searchParams.pairs.join(',');
   if (searchParams.start)
     params.start = getUnixTime(new Date(searchParams.start));
   if (searchParams.end)
@@ -56,14 +51,12 @@ const getQueryParams = (
 
 interface Props {
   params: QueryActivityParams;
-  empty?: ReactNode;
   children: ReactNode;
 }
 type ParamsKey = Extract<keyof QueryActivityParams, string>;
-export const ActivityProvider: FC<Props> = ({ children, params, empty }) => {
+export const ActivityProvider: FC<Props> = ({ children, params }) => {
   const nav = useNavigate();
   const searchParams: ActivitySearchParams = useSearch({ strict: false });
-
   const limit = searchParams.limit ?? 10;
   const offset = searchParams.offset ?? 0;
 
@@ -76,10 +69,6 @@ export const ActivityProvider: FC<Props> = ({ children, params, empty }) => {
   // all filtering items for the base query
   // Note: This could be improved in the backend with a single request, but at the time of writing this code, this was not an option
   const activityMetaQuery = useActivityMetaQuery(params);
-
-  const userStrategiesQuery = useGetUserStrategies({
-    user: queryParams.ownerId,
-  });
 
   const setSearchParams = useCallback(
     (changes: Partial<ActivitySearchParams>) => {
@@ -103,32 +92,12 @@ export const ActivityProvider: FC<Props> = ({ children, params, empty }) => {
     [nav]
   );
 
-  const isPending = activityQuery.isPending || userStrategiesQuery.isPending;
-
-  if (isPending) {
+  if (activityQuery.isPending) {
     return <CarbonLogoLoading className="h-[80px] self-center" />;
   }
   const activities = activityQuery.data ?? [];
   const size = activitySizeQuery.data?.size;
   const meta = activityMetaQuery.data;
-
-  if (!activities.length) {
-    if (empty) {
-      const userStrategies = userStrategiesQuery.data;
-      const userHasNoStrategies =
-        userStrategiesQuery.isFetched &&
-        (!userStrategies || userStrategies.length === 0);
-      if (userHasNoStrategies) return empty;
-    }
-    return (
-      <NotFound
-        variant="error"
-        title="We couldn't find any activities"
-        text="Try entering a different wallet address or choose a different token pair."
-        bordered
-      />
-    );
-  }
 
   const ctx: ActivityContextType = {
     activities,

--- a/src/components/activity/ActivitySection.tsx
+++ b/src/components/activity/ActivitySection.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { ActivityTable } from './ActivityTable';
 import { ActivityFilter, ActivityFilterProps } from './ActivityFilter';
 import { ActivityCountDown } from './ActivityCountDown';
@@ -6,10 +6,13 @@ import { ActivityList } from './ActivityList';
 import { useBreakpoints } from 'hooks/useBreakpoints';
 import { ActivityExport } from './ActivityExport';
 import { useActivity } from './ActivityProvider';
+import { NotFound } from 'components/common/NotFound';
 
-export const ActivitySection: FC<ActivityFilterProps> = ({ filters = [] }) => {
-  const { activities } = useActivity();
-  const { aboveBreakpoint } = useBreakpoints();
+interface LayoutProps extends ActivityFilterProps {
+  children: ReactNode;
+}
+const ActivityLayout: FC<LayoutProps> = (props) => {
+  const { filters = [], children } = props;
   return (
     <section className="bg-background-900 rounded">
       <header className="grid grid-cols-[auto_1fr] gap-16 px-20 py-24 md:grid-cols-[auto_1fr_auto]">
@@ -23,6 +26,31 @@ export const ActivitySection: FC<ActivityFilterProps> = ({ filters = [] }) => {
           <ActivityCountDown time={30} />
         </div>
       </header>
+      {children}
+    </section>
+  );
+};
+
+interface SectionProps extends ActivityFilterProps {
+  empty?: ReactNode;
+}
+export const ActivitySection: FC<SectionProps> = ({ filters = [], empty }) => {
+  const { activities } = useActivity();
+  const { aboveBreakpoint } = useBreakpoints();
+  if (!activities.length) {
+    if (empty) return empty;
+    return (
+      <ActivityLayout filters={filters}>
+        <NotFound
+          variant="error"
+          title="We couldn't find any activities"
+          text="Try entering a different wallet address or choose a different token pair."
+        />
+      </ActivityLayout>
+    );
+  }
+  return (
+    <ActivityLayout filters={filters}>
       {aboveBreakpoint('md') ? (
         <ActivityTable
           activities={activities}
@@ -34,6 +62,6 @@ export const ActivitySection: FC<ActivityFilterProps> = ({ filters = [] }) => {
           hideIds={!filters.includes('ids')}
         />
       )}
-    </section>
+    </ActivityLayout>
   );
 };

--- a/src/pages/strategies/activity/index.tsx
+++ b/src/pages/strategies/activity/index.tsx
@@ -1,13 +1,12 @@
 import { ActivityProvider } from 'components/activity/ActivityProvider';
 import { ActivitySection } from 'components/activity/ActivitySection';
-import { StrategyCreateFirst } from 'components/strategies/overview/StrategyCreateFirst';
 import { useWagmi } from 'libs/wagmi';
 
 export const StrategiesActivityPage = () => {
   const { user } = useWagmi();
   const params = { ownerId: user };
   return (
-    <ActivityProvider params={params} empty={<StrategyCreateFirst />}>
+    <ActivityProvider params={params}>
       <ActivitySection filters={['ids', 'pairs']} />
     </ActivityProvider>
   );


### PR DESCRIPTION
fix #1395

- Pair filter is now working
- Empty state leave the filters

Test case: "Pair filter"
- go to explorer with wallet address: 0x5f7a009664b771e889751f4fd721adc439033ecd
- go to activity tab
- select pair DAI/USDC
- filter works
- add USDC/BBS
-> It only display USDC/BBS, while it should display both. This is because backend response is not correct.

Test case "Empty State"
- go to explorer with wallet address: 0x5f7a009664b771e889751f4fd721adc439033ecd*
- filter by date from 1st of July to 2nd of July
- Display empty state, but filter are accessible