### PR TITLE
Use spread to calculate yPos in the D3ChartOverlapping

### DIFF
--- a/src/components/simulator/input/d3Chart/overlapping/D3ChartOverlapping.tsx
+++ b/src/components/simulator/input/d3Chart/overlapping/D3ChartOverlapping.tsx
@@ -50,21 +50,6 @@ export const D3ChartOverlapping = (props: Props) => {
   const selectorHandleSellMax = getHandleSelector('sell', 'line1');
   const selectorHandleSellMin = getHandleSelector('sell', 'line2');
 
-  const yPos = useMemo(
-    () => ({
-      buy: {
-        min: yScale(Number(prices.buy.min)),
-        max: yScale(Number(prices.buy.max)),
-      },
-      sell: {
-        min: yScale(Number(prices.sell.min)),
-        max: yScale(Number(prices.sell.max)),
-      },
-      marketPrice: marketPrice ? yScale(marketPrice) : 0,
-    }),
-    [prices, yScale, marketPrice]
-  );
-
   const calcPrices = useCallback(
     (buyMin: string, sellMax: string) => {
       return calculateOverlappingPrices(
@@ -76,6 +61,25 @@ export const D3ChartOverlapping = (props: Props) => {
     },
     [marketPrice, spread]
   );
+
+  const yPos = useMemo(() => {
+    const { buyPriceHigh, sellPriceLow } = calcPrices(
+      formatNumber(prices.buy.min),
+      formatNumber(prices.sell.max)
+    );
+
+    return {
+      buy: {
+        min: yScale(Number(prices.buy.min)),
+        max: yScale(Number(buyPriceHigh)),
+      },
+      sell: {
+        min: yScale(Number(sellPriceLow)),
+        max: yScale(Number(prices.sell.max)),
+      },
+      marketPrice: marketPrice ? yScale(marketPrice) : 0,
+    };
+  }, [prices, yScale, marketPrice, calcPrices]);
 
   const onDragBuy = useCallback(
     (y: number) => {


### PR DESCRIPTION
fix #1345

Updating spread was not having an effect in D3ChartOverlapping as the spread was not being used when calculating the yPos for the buyMax and sellMin. Spread is now used with calcPrices to get buyMax and sellMin. 