### PR TITLE
Improve display on approval error message

### DIFF
--- a/src/components/common/approval/ApproveToken.tsx
+++ b/src/components/common/approval/ApproveToken.tsx
@@ -21,7 +21,7 @@ import config from 'config';
 type Props = {
   data?: ApprovalTokenResult;
   isPending: boolean;
-  error: unknown;
+  error: Error | null;
   eventData?: StrategyEventOrTradeEvent & TokenApprovalType;
   context?: 'depositStrategyFunds' | 'createStrategy' | 'trade';
 };
@@ -164,14 +164,14 @@ export const ApproveToken: FC<Props> = ({
 
   if (!data || !token) {
     if (isPending) {
-      return <div>is loading</div>;
+      return <div>Loading...</div>;
     }
     return <div>Unknown Error</div>;
   }
 
   return (
     <>
-      <div className="bg-content h-85 flex items-center justify-between rounded px-20">
+      <div className="bg-content min-h-85 flex items-center justify-between rounded px-20">
         <div className="flex items-center gap-10">
           <LogoImager alt="Token" src={token.logoURI} className="size-30" />
           <p className="font-weight-500">{token.symbol}</p>
@@ -221,7 +221,9 @@ export const ApproveToken: FC<Props> = ({
           </span>
         )}
 
-        {error ? <pre>{JSON.stringify(error, null, 2)}</pre> : null}
+        {error ? (
+          <pre className="max-w-min text-wrap">{error.message}</pre>
+        ) : null}
       </div>
       {data.nullApprovalRequired && (
         <div className="text-14 text-warning flex space-x-20">

--- a/src/components/common/approval/ApproveToken.tsx
+++ b/src/components/common/approval/ApproveToken.tsx
@@ -222,7 +222,7 @@ export const ApproveToken: FC<Props> = ({
         )}
 
         {error ? (
-          <pre className="max-w-min text-wrap">{error.message}</pre>
+          <output className="max-w-min text-wrap">{error.message}</output>
         ) : null}
       </div>
       {data.nullApprovalRequired && (


### PR DESCRIPTION
fix #1346 

- Approval message was showing a JSON.stringify of the error. 
- Since it comes from a tanstack-react query, the error.message can be displayed instead of the entire error object.
- Adjusted the layout of the approval modal so that the height expands as needed to accommodate the error and the error occupies a minimum width.