### PR TITLE
Move trade transaction to a mutation

### DIFF
--- a/src/components/trade/tradeWidget/useBuySell.ts
+++ b/src/components/trade/tradeWidget/useBuySell.ts
@@ -39,7 +39,6 @@ export const useBuySell = ({
   const [isLiquidityError, setIsLiquidityError] = useState(false);
   const [isSourceEmptyError, setIsSourceEmptyError] = useState(false);
   const [isTargetEmptyError, setIsTargetEmptyError] = useState(false);
-  const [isAwaiting, setIsAwaiting] = useState(false);
 
   const { calcMaxInput } = useTradeAction({
     source,
@@ -75,12 +74,11 @@ export const useBuySell = ({
     target,
   ]);
 
-  const { trade, approval } = useTradeAction({
+  const { trade, isAwaiting, approval } = useTradeAction({
     source,
     sourceInput,
     isTradeBySource,
     onSuccess: (txHash: string) => {
-      setIsAwaiting(false);
       clearInputs();
       buy
         ? carbonEvents.trade.tradeBuy({
@@ -236,14 +234,12 @@ export const useBuySell = ({
         isTradeBySource,
         sourceInput: sourceInput,
         targetInput: targetInput,
-        setIsAwaiting,
       });
 
     if (approval.approvalRequired) {
       openModal('txConfirm', {
         approvalTokens: approval.tokens,
         onConfirm: () => {
-          setIsAwaiting(true);
           tradeFn();
         },
         buttonLabel: 'Confirm Trade',
@@ -256,7 +252,6 @@ export const useBuySell = ({
         context: 'trade',
       });
     } else {
-      setIsAwaiting(true);
       void tradeFn();
     }
   }, [

--- a/src/libs/modals/modals/ModalTradeRouting/ModalTradeRouting.tsx
+++ b/src/libs/modals/modals/ModalTradeRouting/ModalTradeRouting.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, KeyboardEvent, useId, useRef, useState } from 'react';
+import { FormEvent, KeyboardEvent, useId, useRef } from 'react';
 import { ModalFC } from '../../modals.types';
 import { Action } from 'libs/sdk';
 import { Token } from 'libs/tokens';
@@ -30,7 +30,6 @@ export const ModalTradeRouting: ModalFC<ModalTradeRoutingData> = ({
 }) => {
   const sourceInputId = useId();
   const table = useRef<HTMLTableElement>(null);
-  const [isAwaiting, setIsAwaiting] = useState(false);
   const { source, target } = data;
   const {
     selected,
@@ -43,9 +42,10 @@ export const ModalTradeRouting: ModalFC<ModalTradeRoutingData> = ({
     disabledCTA,
     buttonText,
     errorMsg,
+    isAwaiting,
   } = useModalTradeRouting({
     id,
-    data: { ...data, setIsAwaiting },
+    data,
   });
 
   const selectedSorted = selected.sort((a, b) => {

--- a/src/libs/modals/modals/ModalTradeRouting/useModalTradeRouting.ts
+++ b/src/libs/modals/modals/ModalTradeRouting/useModalTradeRouting.ts
@@ -1,10 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Action } from '@bancor/carbon-sdk';
 import { useWagmi } from 'libs/wagmi';
 import { ModalTradeRoutingData } from 'libs/modals/modals/ModalTradeRouting/ModalTradeRouting';
@@ -16,9 +10,7 @@ import { SafeDecimal } from 'libs/safedecimal';
 
 type Props = {
   id: string;
-  data: ModalTradeRoutingData & {
-    setIsAwaiting: Dispatch<SetStateAction<boolean>>;
-  };
+  data: ModalTradeRoutingData;
 };
 
 export const useModalTradeRouting = ({
@@ -32,7 +24,6 @@ export const useModalTradeRouting = ({
     onSuccess,
     buy = false,
     sourceBalance,
-    setIsAwaiting,
   },
 }: Props) => {
   const { user, provider } = useWagmi();
@@ -65,14 +56,13 @@ export const useModalTradeRouting = ({
   });
   const sourceInput = data?.totalSourceAmount || '0';
 
-  const { trade, calcMaxInput, approval } = useTradeAction({
+  const { trade, calcMaxInput, isAwaiting, approval } = useTradeAction({
     source,
     isTradeBySource,
     sourceInput,
     onSuccess: () => {
       onSuccess();
       closeModal(id);
-      setIsAwaiting(false);
     },
   });
 
@@ -93,14 +83,12 @@ export const useModalTradeRouting = ({
         isTradeBySource,
         sourceInput,
         targetInput: data.totalTargetAmount,
-        setIsAwaiting,
       });
 
     if (approval.approvalRequired) {
       openModal('txConfirm', {
         approvalTokens: approval.tokens,
         onConfirm: () => {
-          setIsAwaiting(true);
           tradeFn();
         },
         buttonLabel: 'Confirm Trade',
@@ -118,7 +106,6 @@ export const useModalTradeRouting = ({
         },
       });
     } else {
-      setIsAwaiting(true);
       void tradeFn();
     }
   }, [
@@ -136,7 +123,6 @@ export const useModalTradeRouting = ({
     data?.totalSourceAmount,
     data?.totalTargetAmount,
     isTradeBySource,
-    setIsAwaiting,
     buy,
     getFiatValueSource,
     provider?.network?.name,
@@ -181,5 +167,6 @@ export const useModalTradeRouting = ({
     disabledCTA,
     buttonText,
     errorMsg,
+    isAwaiting,
   };
 };

--- a/src/libs/queries/sdk/trade.ts
+++ b/src/libs/queries/sdk/trade.ts
@@ -41,37 +41,27 @@ export const useTradeQuery = () => {
   const { signer } = useWagmi();
 
   return useMutation({
-    mutationFn: async ({
-      isTradeBySource,
-      sourceAddress,
-      targetAddress,
-      tradeActions,
-      deadline,
-      sourceInput,
-      targetInput,
-      calcDeadline,
-      calcMinReturn,
-      calcMaxInput,
-    }: TradeParams) => {
+    mutationFn: async (params: TradeParams) => {
+      const { calcDeadline, calcMinReturn, calcMaxInput } = params;
       let unsignedTx: PopulatedTransaction;
-      if (isTradeBySource) {
+      if (params.isTradeBySource) {
         unsignedTx = await carbonSDK.composeTradeBySourceTransaction(
-          sourceAddress,
-          targetAddress,
-          tradeActions,
-          calcDeadline(deadline),
-          calcMinReturn(targetInput)
+          params.sourceAddress,
+          params.targetAddress,
+          params.tradeActions,
+          calcDeadline(params.deadline),
+          calcMinReturn(params.targetInput)
         );
       } else {
         unsignedTx = await carbonSDK.composeTradeByTargetTransaction(
-          sourceAddress,
-          targetAddress,
-          tradeActions,
-          calcDeadline(deadline),
-          calcMaxInput(sourceInput)
+          params.sourceAddress,
+          params.targetAddress,
+          params.tradeActions,
+          calcDeadline(params.deadline),
+          calcMaxInput(params.sourceInput)
         );
       }
-      return await signer!.sendTransaction(unsignedTx);
+      return signer!.sendTransaction(unsignedTx);
     },
   });
 };

--- a/src/libs/queries/sdk/trade.ts
+++ b/src/libs/queries/sdk/trade.ts
@@ -1,10 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { QueryKey } from 'libs/queries';
 import { SafeDecimal } from 'libs/safedecimal';
 import { useCarbonInit } from 'hooks/useCarbonInit';
 import { Action, TradeActionBNStr } from 'libs/sdk';
-import { MatchActionBNStr } from '@bancor/carbon-sdk';
+import { MatchActionBNStr, PopulatedTransaction } from '@bancor/carbon-sdk';
 import { carbonSDK } from 'libs/sdk';
+import { useWagmi } from 'libs/wagmi';
 
 type GetTradeDataResult = {
   tradeActions: TradeActionBNStr[];
@@ -21,6 +22,58 @@ type Props = {
   input: string;
   isTradeBySource: boolean;
   enabled?: boolean;
+};
+
+export interface TradeParams {
+  sourceAddress: string;
+  targetAddress: string;
+  tradeActions: TradeActionBNStr[];
+  isTradeBySource: boolean;
+  sourceInput: string;
+  targetInput: string;
+  deadline: string;
+  calcDeadline: (value: string) => string;
+  calcMaxInput: (amount: string) => string;
+  calcMinReturn: (amount: string) => string;
+}
+
+export const useTradeQuery = () => {
+  const { signer } = useWagmi();
+
+  return useMutation({
+    mutationFn: async ({
+      isTradeBySource,
+      sourceAddress,
+      targetAddress,
+      tradeActions,
+      deadline,
+      sourceInput,
+      targetInput,
+      calcDeadline,
+      calcMinReturn,
+      calcMaxInput,
+    }: TradeParams) => {
+      let unsignedTx: PopulatedTransaction;
+      if (isTradeBySource) {
+        unsignedTx = await carbonSDK.composeTradeBySourceTransaction(
+          sourceAddress,
+          targetAddress,
+          tradeActions,
+          calcDeadline(deadline),
+          calcMinReturn(targetInput)
+        );
+      } else {
+        unsignedTx = await carbonSDK.composeTradeByTargetTransaction(
+          sourceAddress,
+          targetAddress,
+          tradeActions,
+          calcDeadline(deadline),
+          calcMaxInput(sourceInput)
+        );
+      }
+      return await signer!.sendTransaction(unsignedTx);
+    },
+  });
 };
 
 export const useGetTradeData = ({


### PR DESCRIPTION
fix #675

- Move logic to mutation
- Use isAwaiting = mutation.isPending instead of an awaiting state
- Update everywhere that uses the trade action hook