### PR TITLE
[SENTRY] Change the way fetch signal is timed out on token list fetches

### DIFF
--- a/src/config/sei/utils.ts
+++ b/src/config/sei/utils.ts
@@ -40,9 +40,13 @@ export const tokenSeiListParser =
   };
 
 const getGitFolderContent = async (gitRepoInfoApi: string) => {
-  const signal = AbortSignal.timeout(10000);
+  const controller = new AbortController();
+  const abort = setTimeout(() => {
+    controller.abort();
+  }, 10000);
+  clearTimeout(abort);
   const response = await fetch(gitRepoInfoApi, {
-    signal,
+    signal: controller.signal,
     headers: {
       accept: 'application/vnd.github+json',
       'x-github-api-version': '2022-11-28',

--- a/src/config/sei/utils.ts
+++ b/src/config/sei/utils.ts
@@ -44,7 +44,6 @@ const getGitFolderContent = async (gitRepoInfoApi: string) => {
   const abort = setTimeout(() => {
     controller.abort();
   }, 10000);
-  clearTimeout(abort);
   const response = await fetch(gitRepoInfoApi, {
     signal: controller.signal,
     headers: {
@@ -52,6 +51,7 @@ const getGitFolderContent = async (gitRepoInfoApi: string) => {
       'x-github-api-version': '2022-11-28',
     },
   });
+  clearTimeout(abort);
   return response.json();
 };
 

--- a/src/libs/tokens/tokenHelperFn.ts
+++ b/src/libs/tokens/tokenHelperFn.ts
@@ -13,8 +13,12 @@ const buildIpfsUri = (ipfsHash: string) => `https://ipfs.io/ipfs/${ipfsHash}`;
 export const fetchTokenLists = async () => {
   const res = await Promise.all(
     config.tokenLists.map(async ({ uri, parser }) => {
-      const signal = AbortSignal.timeout(10000);
-      const response = await fetch(uri, { signal });
+      const controller = new AbortController();
+      const abort = setTimeout(() => {
+        controller.abort();
+      }, 10000);
+      const response = await fetch(uri, { signal: controller.signal });
+      clearTimeout(abort);
       const result: TokenList = await response.json();
 
       if (!response.ok) {


### PR DESCRIPTION
fix #1415

Issue was observed in Safari 15.6 and Mobile Safari 15.5.

Versions from Safari > 11.4 and Mobile Safari > 11.3 support [fetch signal](https://caniuse.com/?search=fetch%20signal)
Versions from Safari 16.0 and Mobile Safari > 16.0 support [AbortSignal.timeout().](https://caniuse.com/?search=abortsignal%20timeout)

To support users using Safari 15.6 and Mobile Safari 15.5, the timeout logic for fetching token lists is changed to avoid using AbortSignal.timeout().