### PR TITLE
Fix overlapping chart not updating with spread changes

### DIFF
--- a/src/components/simulator/input/d3Chart/overlapping/D3ChartOverlapping.tsx
+++ b/src/components/simulator/input/d3Chart/overlapping/D3ChartOverlapping.tsx
@@ -1,4 +1,3 @@
-import { calculateOverlappingPrices } from '@bancor/carbon-sdk/strategy-management';
 import { D3ChartCandlesticksProps } from 'components/simulator/input/d3Chart/D3ChartCandlesticks';
 import { D3ChartHandleLine } from 'components/simulator/input/d3Chart/D3ChartHandleLine';
 import { D3ChartPriceOutOfScale } from 'components/simulator/input/d3Chart/D3ChartPriceOutOfScale';
@@ -19,8 +18,9 @@ import {
   getMinSellMax,
 } from 'components/strategies/overlapping/utils';
 import { ScaleLinear } from 'd3';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { formatNumber, prettifyNumber } from 'utils/helpers';
+import { useCallback, useEffect, useRef } from 'react';
+import { prettifyNumber } from 'utils/helpers';
+import { useD3OverlappingChart } from './useD3OverlappingChart';
 
 type Props = Pick<
   D3ChartCandlesticksProps,
@@ -50,32 +50,12 @@ export const D3ChartOverlapping = (props: Props) => {
   const selectorHandleSellMax = getHandleSelector('sell', 'line1');
   const selectorHandleSellMin = getHandleSelector('sell', 'line2');
 
-  const yPos = useMemo(
-    () => ({
-      buy: {
-        min: yScale(Number(prices.buy.min)),
-        max: yScale(Number(prices.buy.max)),
-      },
-      sell: {
-        min: yScale(Number(prices.sell.min)),
-        max: yScale(Number(prices.sell.max)),
-      },
-      marketPrice: marketPrice ? yScale(marketPrice) : 0,
-    }),
-    [prices, yScale, marketPrice]
-  );
-
-  const calcPrices = useCallback(
-    (buyMin: string, sellMax: string) => {
-      return calculateOverlappingPrices(
-        formatNumber(buyMin),
-        formatNumber(sellMax),
-        marketPrice?.toString() ?? '0',
-        spread.toString()
-      );
-    },
-    [marketPrice, spread]
-  );
+  const { calcPrices, yPos } = useD3OverlappingChart({
+    prices,
+    yScale,
+    spread,
+    marketPrice,
+  });
 
   const onDragBuy = useCallback(
     (y: number) => {

--- a/src/components/simulator/input/d3Chart/overlapping/useD3OverlappingChart.test.ts
+++ b/src/components/simulator/input/d3Chart/overlapping/useD3OverlappingChart.test.ts
@@ -1,0 +1,126 @@
+import { renderHook } from 'libs/testing-library';
+import { useLinearScale } from 'libs/d3';
+import { getDomain } from '../utils';
+import { expect, describe, it } from 'vitest';
+import { useD3OverlappingChart } from './useD3OverlappingChart';
+import { formatNumber } from 'utils/helpers';
+
+describe('useYPos', () => {
+  it('should handle case where prices.buy.min or prices.sell.max are non-zero', () => {
+    const prices = {
+      buy: { min: '0.6', max: '1.2' },
+      sell: { min: '0.8', max: '1.6' },
+    };
+    const bounds = {
+      buy: { min: '0', max: '3' },
+      sell: { min: '0.8', max: '3' },
+    };
+    const spread = 5;
+    const marketPrice = 1.0;
+    const maxRange = 300;
+
+    const { result: linearScaleResult } = renderHook(() =>
+      useLinearScale({
+        domain: getDomain([], bounds, marketPrice),
+        range: [maxRange, 0],
+        domainTolerance: 0.1,
+      })
+    );
+    const yScale = linearScaleResult.current.scale;
+
+    const { result } = renderHook(() =>
+      useD3OverlappingChart({ prices, yScale, spread, marketPrice })
+    );
+
+    const { buyPriceHigh, sellPriceLow } = result.current.calcPrices(
+      formatNumber(prices.buy.min),
+      formatNumber(prices.sell.max)
+    );
+
+    expect(buyPriceHigh).not.toEqual(prices.buy.min);
+    expect(sellPriceLow).not.toEqual(prices.sell.max);
+
+    expect(result.current.yPos).toStrictEqual({
+      buy: {
+        min: yScale(Number(prices.buy.min)),
+        max: yScale(Number(buyPriceHigh)),
+      },
+      sell: {
+        min: yScale(Number(sellPriceLow)),
+        max: yScale(Number(prices.sell.max)),
+      },
+      marketPrice: yScale(marketPrice),
+    });
+  });
+  it('should handle case where prices.buy.min or prices.sell.max are zero', () => {
+    const prices = {
+      buy: { min: '0', max: '1.2' },
+      sell: { min: '0.8', max: '0' },
+    };
+    const bounds = {
+      buy: { min: '0', max: '1' },
+      sell: { min: '0.8', max: '3' },
+    };
+    const spread = 5;
+    const marketPrice = 0.9;
+    const maxRange = 300;
+
+    const { result: linearScaleResult } = renderHook(() =>
+      useLinearScale({
+        domain: getDomain([], bounds, marketPrice),
+        range: [maxRange, 0],
+        domainTolerance: 0.1,
+      })
+    );
+    const yScale = linearScaleResult.current.scale;
+
+    const { result } = renderHook(() =>
+      useD3OverlappingChart({ prices, yScale, spread, marketPrice })
+    );
+
+    const { buyPriceHigh, sellPriceLow } = result.current.calcPrices(
+      formatNumber(prices.buy.min),
+      formatNumber(prices.sell.max)
+    );
+
+    expect(result.current.yPos).toStrictEqual({
+      buy: {
+        min: yScale(Number(prices.buy.min)),
+        max: yScale(Number(buyPriceHigh)),
+      },
+      sell: {
+        min: yScale(Number(sellPriceLow)),
+        max: yScale(Number(prices.sell.max)),
+      },
+      marketPrice: yScale(marketPrice),
+    });
+  });
+  it('should handle case with no marketPrice', () => {
+    const prices = {
+      buy: { min: '0', max: '1.2' },
+      sell: { min: '0.8', max: '0' },
+    };
+    const bounds = {
+      buy: { min: '0', max: '1' },
+      sell: { min: '0.8', max: '3' },
+    };
+    const spread = 5;
+    const marketPrice = 0.9;
+    const maxRange = 300;
+
+    const { result: linearScaleResult } = renderHook(() =>
+      useLinearScale({
+        domain: getDomain([], bounds, marketPrice),
+        range: [maxRange, 0],
+        domainTolerance: 0.1,
+      })
+    );
+    const yScale = linearScaleResult.current.scale;
+
+    const { result } = renderHook(() =>
+      useD3OverlappingChart({ prices, yScale, spread })
+    );
+
+    expect(result.current.yPos.marketPrice).toEqual(0);
+  });
+});

--- a/src/components/simulator/input/d3Chart/overlapping/useD3OverlappingChart.ts
+++ b/src/components/simulator/input/d3Chart/overlapping/useD3OverlappingChart.ts
@@ -1,0 +1,59 @@
+import { ScaleLinear } from 'd3';
+import { ChartPrices } from '../D3ChartCandlesticks';
+import { useCallback, useMemo } from 'react';
+import { calculateOverlappingPrices } from '@bancor/carbon-sdk/strategy-management';
+import { formatNumber } from 'utils/helpers';
+
+interface Props {
+  prices: ChartPrices<string>;
+  yScale: ScaleLinear<number, number, never>;
+  spread: number;
+  marketPrice?: number;
+}
+
+export const useD3OverlappingChart = (props: Props) => {
+  const { prices, yScale, spread, marketPrice } = props;
+
+  const calcPrices = useCallback(
+    (buyMin: string, sellMax: string) => {
+      return calculateOverlappingPrices(
+        formatNumber(buyMin),
+        formatNumber(sellMax),
+        marketPrice?.toString() ?? '0',
+        spread.toString()
+      );
+    },
+    [marketPrice, spread]
+  );
+
+  const yPos = useMemo(() => {
+    let buyMax = prices.buy.max;
+    let sellMin = prices.sell.min;
+
+    if (prices.buy.min && prices.sell.max) {
+      const calculatedPrices = calcPrices(
+        formatNumber(prices.buy.min),
+        formatNumber(prices.sell.max)
+      );
+      buyMax = calculatedPrices.buyPriceHigh;
+      sellMin = calculatedPrices.sellPriceLow;
+    }
+
+    return {
+      buy: {
+        min: yScale(Number(prices.buy.min)),
+        max: yScale(Number(buyMax)),
+      },
+      sell: {
+        min: yScale(Number(sellMin)),
+        max: yScale(Number(prices.sell.max)),
+      },
+      marketPrice: marketPrice ? yScale(marketPrice) : 0,
+    };
+  }, [prices, yScale, marketPrice, calcPrices]);
+
+  return {
+    calcPrices,
+    yPos,
+  };
+};


### PR DESCRIPTION
- Move yPos and calcPrices to a separate hook
- Use calcPrices to get buyMax and sellMin
- Add tests for the hook

fix #1345