### PR TITLE
[Simulator] Fix replay increasing speed

### DIFF
--- a/src/components/simulator/result/SimResultChartControls.tsx
+++ b/src/components/simulator/result/SimResultChartControls.tsx
@@ -15,6 +15,7 @@ export const SimResultChartControls = () => {
     status,
     start,
     end,
+    replay,
     playbackSpeed,
     setPlaybackSpeed,
     data,
@@ -33,11 +34,6 @@ export const SimResultChartControls = () => {
   const setSpeed = (speed: PlaybackSpeed) => {
     setPlaybackSpeed(speed);
     setIsOpen(false);
-  };
-
-  const replay = () => {
-    end();
-    start();
   };
 
   const playPause = () => {

--- a/src/components/simulator/result/SimulatorProvider.tsx
+++ b/src/components/simulator/result/SimulatorProvider.tsx
@@ -26,6 +26,7 @@ interface SimulatorProviderCTX extends Partial<SimulatorReturn> {
   status: SimulationStatus;
   start: () => void;
   end: () => void;
+  replay: () => void;
   pause: () => void;
   unpause: () => void;
   onBrush: (frame: number) => void;
@@ -152,6 +153,15 @@ export const SimulatorProvider: FC<SimulatorProviderProps> = ({ children }) => {
     setAnimationData(query.data?.data || []);
   };
 
+  const replay = useCallback(() => {
+    setAnimationData([]);
+    animationFrame.current = 0;
+    if (status.current !== 'running') {
+      status.current = 'running';
+      handleAnimationStep();
+    }
+  }, [handleAnimationStep]);
+
   const onBrush = (frame: number) => {
     if (!actionAfterBrushEnd.current) {
       if (status.current === 'running') {
@@ -194,6 +204,7 @@ export const SimulatorProvider: FC<SimulatorProviderProps> = ({ children }) => {
         animationData,
         start,
         end,
+        replay,
         onBrush,
         onBrushEnd,
         pause,


### PR DESCRIPTION
- Reply function only calls handleAnimationStep if it is not already running, in which cases the handleAnimationStep look is already happening
- Use replay function in SimResultChartControls

fix #1217