### PR TITLE
Redirect app to correct app URL in a Safe Wallet

### DIFF
--- a/src/components/core/menu/mainMenu/MainMenuRightChainSelector.tsx
+++ b/src/components/core/menu/mainMenu/MainMenuRightChainSelector.tsx
@@ -11,6 +11,7 @@ interface Props {
     name: string;
     logoUrl: string;
     appUrl: string;
+    chainId: number;
     isCurrentNetwork: boolean;
   }[];
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -48,6 +48,7 @@ export const networks = Object.entries(configs)
       id,
       name: config[mode].network.name,
       logoUrl: config[mode].network.logoUrl,
+      chainId: config[mode].network.chainId,
       isCurrentNetwork: network === id,
       appUrl: config[mode].appUrl,
     };

--- a/src/libs/wagmi/connectors.ts
+++ b/src/libs/wagmi/connectors.ts
@@ -9,7 +9,7 @@ import {
   walletConnect,
   safe,
 } from 'wagmi/connectors';
-import config from 'config';
+import config, { networks } from 'config';
 import {
   type SelectableConnectionName,
   providerMapRdnsToName,
@@ -111,6 +111,19 @@ const getDefaultConnector = (connectorType: SelectableConnectionName) => {
 
 const isIframe = () =>
   typeof window !== 'undefined' && window?.parent !== window;
+
+export const redirectSafeWallet = (
+  currentId: number,
+  redirectToId?: number
+) => {
+  if (isIframe() && redirectToId && currentId !== redirectToId) {
+    const networkToRedirect = networks.find(
+      (network) => Number(network.chainId) === redirectToId
+    );
+    if (!networkToRedirect) return;
+    window.location.href = networkToRedirect.appUrl;
+  }
+};
 
 export const providerRdnsToName = (
   connectionName: string

--- a/src/libs/wagmi/connectors.ts
+++ b/src/libs/wagmi/connectors.ts
@@ -118,7 +118,7 @@ export const redirectSafeWallet = (
 ) => {
   if (isIframe() && redirectToId && currentId !== redirectToId) {
     const networkToRedirect = networks.find(
-      (network) => Number(network.chainId) === redirectToId
+      (network) => network.chainId === redirectToId
     );
     if (!networkToRedirect) return;
     window.location.href = networkToRedirect.appUrl;

--- a/src/libs/wagmi/useWagmiUser.ts
+++ b/src/libs/wagmi/useWagmiUser.ts
@@ -17,6 +17,7 @@ import { errorMessages } from './wagmi.utils';
 import { clientToSigner } from './ethers';
 import { getUncheckedSigner } from 'utils/tenderly';
 import { carbonEvents } from 'services/events';
+import { redirectSafeWallet } from './connectors';
 
 type Props = {
   imposterAccount?: string;
@@ -87,6 +88,7 @@ export const useWagmiUser = ({
           address: data.address,
           name: data.connector.name,
         });
+        redirectSafeWallet(chainId, accountChainId);
       }
       if (window?.OneTrust) {
         window?.OneTrust?.AllowAll();


### PR DESCRIPTION
By default, safe wallet opens the CarbonDeFi app on https://app.carbondefi.xyz:

Detect redirection must be made:
- User is in an iFrame - meaning CarbonDeFi is open on a Safe Wallet as this is the only external address frame-ancestor allowed in the CSP
- Current chain Id is different than safe wallet chain Id

fix #1398