### PR TITLE
Fix limit/offset wrong parsing

### DIFF
--- a/src/components/activity/ActivityProvider.tsx
+++ b/src/components/activity/ActivityProvider.tsx
@@ -59,8 +59,8 @@ type ParamsKey = Extract<keyof QueryActivityParams, string>;
 export const ActivityProvider: FC<Props> = ({ children, params }) => {
   const nav = useNavigate();
   const searchParams: ActivitySearchParams = useSearch({ strict: false });
-  const limit = searchParams.limit ?? 10;
-  const offset = searchParams.offset ?? 0;
+  const limit = searchParams.limit;
+  const offset = searchParams.offset;
 
   const queryParams = getQueryParams(params, searchParams);
   // Query the list

--- a/src/components/activity/utils.ts
+++ b/src/components/activity/utils.ts
@@ -4,7 +4,7 @@ import {
   SearchParamsValidator,
   validArrayOf,
   validLiteral,
-  validNumberType,
+  validNumber,
   validString,
   validateSearchParams,
 } from 'libs/routing/utils';
@@ -45,10 +45,19 @@ export const activityValidators: SearchParamsValidator<ActivitySearchParams> = {
   pairs: validArrayOf(validString),
   start: validString,
   end: validString,
-  limit: validNumberType,
-  offset: validNumberType,
+  limit: validNumber,
+  offset: validNumber,
 };
-export const validateActivityParams = validateSearchParams(activityValidators);
+export const validateActivityParams = (search: Record<string, string>) => {
+  const rawSearch = validateSearchParams(activityValidators)(search);
+  const limit = Number(rawSearch.limit ?? 10);
+  const offset = Number(rawSearch.offset ?? 0);
+  return {
+    ...rawSearch,
+    limit,
+    offset,
+  };
+};
 
 export const activityHasPairs = (activity: Activity, pairs: string[] = []) => {
   if (pairs.length === 0) return true;


### PR DESCRIPTION
If searchValidateParams is set for a route, it will override the params returned by parseSearch in the Router. So the validateActivityParams was just doing a validation and not parsing the limit and offset + setting a default value as it should.