### PR TITLE
Bump browserslist DB to 1.0.30001679

### DIFF
--- a/.github/workflows/update_browserslist.yaml
+++ b/.github/workflows/update_browserslist.yaml
@@ -1,7 +1,7 @@
 name: Update Browserslist DB
 on:
   schedule:
-    - cron: '0 0 * * 0' # Runs every week at 00:00 on Sunday
+    - cron: '0 0 1 * *' # Runs every month at 00:00 on the 1st
   workflow_dispatch: # Allows manual triggering of the workflow
 jobs:
   update-browserslist-db:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5023,9 +5023,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001629, caniuse-lite@^1.0.30001639, caniuse-lite@^1.0.30001640:
-  version "1.0.30001677"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz"
-  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
+  version "1.0.30001679"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz"
+  integrity sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==
 
 "cbw-sdk@npm:@coinbase/wallet-sdk@3.9.3":
   version "3.9.3"


### PR DESCRIPTION
Bumps caniuse-lite to 1.0.30001679.
Update output: 
yarn run v1.22.22
$ npx update-browserslist-db@latest
Latest version:     1.0.30001679
Installed version:  1.0.30001677
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
caniuse-lite has been successfully updated

No target browser changes
Done in 17.29s.