### PR TITLE
[Debug] clear localstorage on reset config

### DIFF
--- a/src/components/debug/DebugConfig.tsx
+++ b/src/components/debug/DebugConfig.tsx
@@ -21,14 +21,14 @@ export const DebugConfig = () => {
     try {
       if (!configOverride) {
         setConfigOverride('');
+        localStorage.clear();
         lsService.removeItem('configOverride');
+        window?.location.reload();
       } else {
         const parsedConfig = JSON.parse(configOverride || '');
         const result = v.safeParse(v.partial(AppConfigSchema), parsedConfig);
         if (result.success) {
-          for (let i = 0; i < localStorage.length; i++) {
-            localStorage.removeItem(localStorage.key(i)!);
-          }
+          localStorage.clear();
           lsService.setItem('configOverride', parsedConfig);
           window?.location.reload();
         } else {


### PR DESCRIPTION
fix #1658 

How to test : 
- Go to debug
- Enter a config file
- click save
-> It should reload
- go to trade: you should see USDCbc & BSWAP
- go back to debug
- under config section click on reset
-> It should reload
- go back to trade: you should see ETH & USDC