### PR TITLE
Load missing tokens - Trade / Simulate

### DIFF
--- a/src/hooks/useSimulatorOverlappingInput.ts
+++ b/src/hooks/useSimulatorOverlappingInput.ts
@@ -2,7 +2,7 @@
 import { useNavigate } from '@tanstack/react-router';
 import { useDebouncedValue } from 'hooks/useDebouncedValue';
 import { StrategyInputOrder } from 'hooks/useStrategyInput';
-import { useTokens } from 'hooks/useTokens';
+import { useToken } from 'hooks/useTokens';
 import { SimulatorInputOverlappingSearch } from 'libs/routing/routes/sim';
 import { Token } from 'libs/tokens';
 import { useCallback, useMemo, useState } from 'react';
@@ -41,19 +41,12 @@ export interface SimulatorInputOverlappingValues {
 }
 
 export const useSimulatorOverlappingInput = ({ searchState }: Props) => {
-  const { getTokenById } = useTokens();
   const navigate = useNavigate({ from: '/simulate/overlapping' });
   const [_state, setState] =
     useState<InternalSimulatorOverlappingInput>(searchState);
 
-  const baseToken = useMemo(
-    () => getTokenById(_state.baseToken),
-    [_state.baseToken, getTokenById]
-  );
-  const quoteToken = useMemo(
-    () => getTokenById(_state.quoteToken),
-    [_state.quoteToken, getTokenById]
-  );
+  const baseToken = useToken(_state.baseToken);
+  const quoteToken = useToken(_state.quoteToken);
 
   const state = buildStrategyInputState(_state, baseToken, quoteToken);
 

--- a/src/hooks/useStrategyInput.ts
+++ b/src/hooks/useStrategyInput.ts
@@ -1,10 +1,10 @@
 /* eslint-disable unused-imports/no-unused-vars */
 import { useNavigate } from '@tanstack/react-router';
 import { useDebouncedValue } from 'hooks/useDebouncedValue';
-import { useTokens } from 'hooks/useTokens';
+import { useToken } from 'hooks/useTokens';
 import { StrategyInputSearch } from 'libs/routing/routes/sim';
 import { Token } from 'libs/tokens';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export interface InternalStrategyInput extends StrategyInputSearch {
   sellBudgetError?: string;
@@ -42,18 +42,11 @@ interface Props {
 }
 
 export const useStrategyInput = ({ searchState }: Props) => {
-  const { getTokenById } = useTokens();
   const navigate = useNavigate({ from: '/simulate/recurring' });
   const [_state, setState] = useState<InternalStrategyInput>(searchState);
 
-  const baseToken = useMemo(
-    () => getTokenById(_state.baseToken),
-    [_state.baseToken, getTokenById]
-  );
-  const quoteToken = useMemo(
-    () => getTokenById(_state.quoteToken),
-    [_state.quoteToken, getTokenById]
-  );
+  const baseToken = useToken(_state.baseToken);
+  const quoteToken = useToken(_state.quoteToken);
 
   const state = buildStrategyInputState(_state, baseToken, quoteToken);
 

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -1,9 +1,11 @@
-import { utils } from 'ethers';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Token } from 'libs/tokens';
 import { lsService } from 'services/localeStorage';
 import { useStore } from 'store';
 import { useWagmi } from 'libs/wagmi';
+import { useContract } from './useContract';
+import { fetchTokenData } from 'libs/tokens/tokenHelperFn';
+import { utils } from 'ethers';
 
 export const useTokens = () => {
   const { user } = useWagmi();
@@ -18,19 +20,20 @@ export const useTokens = () => {
 
   const importTokens = useCallback(
     (tokens: Token[]) => {
-      const missing: Token[] = [];
-      for (const token of tokens) {
-        if (getTokenById(token.address)) continue;
-        const normalizedAddress = utils.getAddress(token.address);
-        missing.push({ ...token, address: normalizedAddress });
-      }
-
-      const lsImportedTokens = lsService.getItem('importedTokens') ?? [];
-      const newTokens = [...lsImportedTokens, ...missing];
-      setImportedTokens(newTokens);
-      lsService.setItem('importedTokens', newTokens);
+      setImportedTokens((existing) => {
+        const map = new Map();
+        for (const item of existing) map.set(item.address, item);
+        const missing: Token[] = [];
+        for (const token of tokens) {
+          const normalizedAddress = utils.getAddress(token.address);
+          if (map.has(normalizedAddress)) continue;
+          missing.push({ ...token, address: normalizedAddress });
+        }
+        if (!missing.length) return existing;
+        return [...existing, ...missing];
+      });
     },
-    [getTokenById, setImportedTokens]
+    [setImportedTokens]
   );
 
   const [favoriteTokens, _setFavoriteTokens] = useState<Token[]>(
@@ -70,4 +73,20 @@ export const useTokens = () => {
     favoriteTokens,
     tokensMap,
   };
+};
+
+export const useToken = (address?: string) => {
+  const { getTokenById, importTokens } = useTokens();
+  const { Token } = useContract();
+  const [token, setToken] = useState<Token | undefined>();
+  useEffect(() => {
+    if (!address) return;
+    const existing = getTokenById(address);
+    if (existing) return setToken(existing);
+    fetchTokenData(Token, address).then((token) => {
+      setToken(token);
+      importTokens([token]);
+    });
+  }, [getTokenById, address, Token, importTokens]);
+  return token;
 };

--- a/src/pages/trade/root.tsx
+++ b/src/pages/trade/root.tsx
@@ -2,18 +2,17 @@ import { Outlet } from '@tanstack/react-router';
 import { NotFound } from 'components/common/NotFound';
 import { TradeProvider } from 'components/trade/TradeContext';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { useTokens } from 'hooks/useTokens';
+import { useToken } from 'hooks/useTokens';
 import { TradeSearch } from 'libs/routing';
 import { getLastVisitedPair } from 'libs/routing/utils';
 import { useEffect } from 'react';
 import { lsService } from 'services/localeStorage';
 
 export const usePersistLastPair = (from: '/trade') => {
-  const { getTokenById } = useTokens();
   const search = useSearch({ strict: false }) as TradeSearch;
   const defaultPair = getLastVisitedPair();
-  const base = getTokenById(search.base ?? defaultPair.base);
-  const quote = getTokenById(search.quote ?? defaultPair.quote);
+  const base = useToken(search.base ?? defaultPair.base);
+  const quote = useToken(search.quote ?? defaultPair.quote);
 
   useEffect(() => {
     if (!base || !quote) return;

--- a/src/store/useTokensStore.ts
+++ b/src/store/useTokensStore.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { Token } from 'libs/tokens';
 import { useTokensQuery } from 'libs/queries';
 import { lsService } from 'services/localeStorage';
@@ -18,6 +18,10 @@ export const useTokensStore = (): TokensStore => {
   const [importedTokens, setImportedTokens] = useState<Token[]>(
     lsService.getItem('importedTokens') ?? []
   );
+
+  useEffect(() => {
+    lsService.setItem('importedTokens', importedTokens);
+  }, [importedTokens]);
 
   const tokens = useMemo(() => {
     if (!tokensQuery.data?.length) return [];


### PR DESCRIPTION
fix #1737
Ensure missing tokens are fetch in trade & simulate pages.

How to test: 
- Go to `/trade/disposable?base=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&quote=0x15b0dd2c5db529ab870915ff498bea6d20fb6b96`
- Open devtool, clear localstorage
- Reload
- The page should display the PARQ token