### PR TITLE
Disable Seitrace assetlist

### DIFF
--- a/src/config/sei/common.ts
+++ b/src/config/sei/common.ts
@@ -99,10 +99,10 @@ export const commonConfig: AppConfig = {
     },
   ],
   tokenLists: [
-    {
-      uri: 'https://raw.githubusercontent.com/Seitrace/sei-assetlist/refs/heads/main/assetlist.json',
-      parser: 'tokenSeiListParser',
-    },
+    // {
+    //   uri: 'https://raw.githubusercontent.com/Seitrace/sei-assetlist/refs/heads/main/assetlist.json',
+    //   parser: 'tokenSeiListParser',
+    // },
     {
       uri: 'https://raw.githubusercontent.com/Sei-Public-Goods/sei-assetlist/main/assetlist.json',
       parser: 'tokenSeiListParser',


### PR DESCRIPTION
There's an issue with JSON.parse introduced by a wrong format from the Seitrace assetlist.

This PR disables this assetlist temporarily until the [issue is resolved](https://github.com/Seitrace/sei-assetlist/pull/20).