### PR TITLE
Bump browserslist DB to 1.0.30001762

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4299,9 +4299,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001640, caniuse-lite@^1.0.30001669:
-  version "1.0.30001757"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz"
-  integrity sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==
+  version "1.0.30001762"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz"
+  integrity sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==
 
 case-shift@^2.5.3:
   version "2.5.3"


### PR DESCRIPTION
Bumps caniuse-lite to 1.0.30001762.
Update output: 
yarn run v1.22.22
$ npx update-browserslist-db@latest
Latest version:     1.0.30001762
Installed version:  1.0.30001757
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite baseline-browser-mapping
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite baseline-browser-mapping
caniuse-lite has been successfully updated

No target browser changes
Done in 19.14s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency lockfile only.
> 
> - Bumps `caniuse-lite` in `yarn.lock` to `1.0.30001762` (from `1.0.30001757`)
> - No application code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7b61bbf333e56aaf6072653cb62ea0bc8327603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->